### PR TITLE
Soft api version

### DIFF
--- a/doc/plugins.dox
+++ b/doc/plugins.dox
@@ -40,7 +40,7 @@ We will try to document as many functions and structs as possible.
 
 @section pluginsupport Plugin Support
 - @link howto Plugin HowTo @endlink - get started
-- @link legacy Legacy Plugin Entry Points and Transition to the Modern ones @endlink
+- @ref legacy
 - @link plugindata.h Plugin Datatypes and Macros @endlink
 - @link pluginsignals.c Plugin Signals @endlink
 - @link pluginutils.h Plugin Utility Functions @endlink
@@ -172,56 +172,61 @@ Geany's website at http://www.geany.org/Support/BuildingOnWin32.
 @section helloworld "Hello World"
 
 @note This section describes the new entry points for plugins introduced with Geany 1.26. A short
-summary of the legacy entry points is given at page @ but it should not be used any more.
+summary of the legacy entry points is given at page @ref legacy but they are deprecated should not
+be used any more.
 
-When writing a plugin, you will find a couple of functions which are mandatory and some which are
-free to use for implementing some useful feature once your plugin becomes more powerful like
-including a configuration or help dialog.
+When writing a plugin you will find a couple of functions which are mandatory and some which can be
+implemented optionally for implementing some useful features once your plugin becomes more
+powerful. For example to provide a configuration or help dialog.
 
-@subsection beginning Beginnings of any Plugin
+@subsection beginning First steps for any Plugin
 
-You should start your plugin with including some of the needed C header files and defining
-some basic global variables which will help you to access all needed functions of the plugin
-API in a more comfortable way.
+You should start your plugin with including <geanyplugin.h> and exporting a function named @a
+geany_load_module(). In this function you must fill in basic information that Geany uses to learn
+more about your plugin and present it to the user. You also must define some hooks that enable
+Geany to actually execute your code.
 
 Please also do not forget about license headers which are by convention at the start of source
-files. You can use templates provided by Geany to get started.
+files. You can use templates provided by Geany to get started. Without a proper license it will be
+difficult for packagers to pick up and distribute your plugin.
 
-Let's start with the very basic headers and add more later if necessary.
+As mentioned above, start with the very fundamental header that gets you all goodies of Geany's
+plugin API. @a geanyplugin.h includes all of the Geany API and also the necessary GTK header
+files so there is no need to include @a gtk/gtk.h yourself. In fact it includes a utility header
+that helps supporting GTK+2 and GTK+3 in the same source.
+
 @code
 #include <geanyplugin.h>
 @endcode
 
-@a geanyplugin.h includes all of the Geany API and also the necessary GTK header files,
-so there is no need to include @a gtk/gtk.h yourself.
+@note If you use autoconf then config.h must be included even before that as usual.
 
-@note @a plugindata.h contains the biggest part of the plugin API and provides some basic macros.
-
-Now you can go on and write your first lines for your new plugin. As mentioned before,
-you will need to implement and a couple of functions. Arguably the most important
-one is @a geany_load_module(). This is the function that makes Geany see you plugin at all. When
-Geany scans the pre-defined and user-configured plugin directories, it will take a look at each
-shared library (or DLL on Windows) to see if it exports a @a geany_load_module() symbol. Files
-lacking these will be outright ignored.
+Now you can go on and write your first lines for your new plugin. As mentioned before, you will
+need to implement a couple of functions. The first mandatory one is @a geany_load_module(). Geany
+uses the presence fo this function to identify a library as a plugin. When Geany scans the
+pre-defined and user-configured plugin directories, it will take a look at each shared library (or
+DLL on Windows) to see if it exports a @a geany_load_module() symbol. Files lacking these will be
+ignored. The second mandatory one is an initialization function that is only called when the plugin
+becomes actually enabled (by the user or at startup).
 
 @subsection register Registering a Plugin
 
-Geany will then invoke this function, always and regardless of whether the user activates your
+Geany will always invoke this geany_load_module(), regardless of whether the user activates your
 plugin. In fact its purpose to probe if the plugin should even be presented to the user. Therefore
-it important that you use this function to register your plugin, making it available to the user.
-Geany will pass a pointer to a GeanyPlugin instance which acts as a unique handle to your plugin.
-Use this pointer for registering and later API calls. Registering the plugin consists of a number
-of steps:
+you must use this function to register your plugin. Geany will pass a pointer to a GeanyPlugin
+instance which acts as a unique handle to your plugin. Use this pointer for registering and later
+API calls. It won't change for the life time of the plugin. Registering the plugin consists of a
+number of steps:
 
-  1. Filling GeanyPlugin::info with metadata
+  1. Filing in GeanyPlugin::info with metadata that is shown to the user.
     - @ref PluginInfo::name : The name of your plugin
     - @ref PluginInfo::description : A brief description.
-    - @ref PluginInfo::version : The current version.
-    - @ref PluginInfo::author : Your contanct information.
+    - @ref PluginInfo::version : The plugin's version.
+    - @ref PluginInfo::author : Your contact information, preferably in the form "Name <email>".
     .
-    Filling all of them is recommended to provide the best user experience, but only the name is truly
-    mandatory.
-  2. Filling GeanyPlugin::funcs with function pointers
+    Filing in all of them is recommended to provide the best user experience, but only the name is
+    truly mandatory. Since all of the strings are shown to the user they should be human readable.
+  2. Filing in GeanyPlugin::funcs with function pointers that are called by Geany.
     - @ref GeanyPluginFuncs::init : an initialization function
     - @ref GeanyPluginFuncs::cleanup : a finalization function
     - @ref GeanyPluginFuncs::configure : a function that provides configuration (optional)
@@ -229,16 +234,17 @@ of steps:
     - @ref GeanyPluginFuncs::callbacks : a pointer to an array of PluginCallback (optional).
     .
     @a init and @a cleanup are mandatory, the other ones depend on how advanced your plugin is.
-    Furthermore, the @a init and @a cleanup
-    pair is called when the user activates your plugin in the Plugin Manager. So use these to
-    do advanced initialization and teardown as to not waste resources when the plugin is not even
+    Furthermore, the @a init and @a cleanup pair is called when the user activates and deactivates
+    your plugin in the Plugin Manager, and on startup and exit respectively. So use these to do
+    advanced initialization and teardown as to not waste resources when the plugin is not even
     enabled.
-  3. Registering for real by calling @a geany_plugin_register(). You must pass the GeanyPlugin
-    pointer that your received and filled out as above. geany_plugin_register() also takes
-    various version numbers which are detailed below. Please <b>use the macro @a
-    GEANY_PLUGIN_REGISTER()</b> where you only specify the minimum API version. Please also
-    <b>observer the return value</b> of geany_plugin_register(). Geany may refuse to load your
-    plugin due to incompatibilities, you should then abort any extra setup.
+  3. Actually registering by calling GEANY_PLUGIN_REGISTER(), passing the GeanyPlugin pointer that
+    you received and filled out as above. GEANY_PLUGIN_REGISTER() also takes the minimum API
+    version number you want to support (see @ref versions for details). Please also <b>check the
+    return value</b>. Geany may refuse to load your plugin due to
+    incompatibilities, you should then abort any extra setup. GEANY_PLUGIN_REGISTER() is a macro
+    wrapping geany_plugin_register() which takes additional the API and ABI that you should not
+    pass manually.
   4. Optionally setting user data that is passed to GeanyPlugin::funcs with geany_plugin_set_data().
     Here you can set a data pointer that is passed back to your functions called by Geany. This
     allows to avoid global variables which may be useful. It also allows to set instance pointer
@@ -254,37 +260,39 @@ As previously mentioned @a geany_plugin_register() takes a number of versions as
   2. min_api_version
   3. abi_version
 
-These refer to Geany's versioning scheme to manage plugin compatibility. It follows conrete rules:
-  - Plugins are compiled against a specific Geany version on the build machine at the time of plugin
-    compilation. This version of Geany has specific ABI and API versions, which will be compiled
-    into the plugin.
+These refer to Geany's versioning scheme to manage plugin compatibility. The following rules apply:
+  - Plugins are compiled against a specific Geany version on the build machine. This version of
+    Geany has specific ABI and API versions, which will be compiled into the plugin. Both are
+    managed automatically, by calling GEANY_PLUGIN_REGISTER().
   - The Geany version that loads the plugin may be different, possibly even have different API and
     ABI versions.
-  - The ABI version is primary for plugin compatibility. The ABI version of the running Geany and
-    the one that's compiled into the plugin must match exactly (==). In case of mismatch, the
-    affected plugins generally need to be simply recompiled (without source code changes) against
-    the running Geany.
+  - The ABI version is the primary plugin compatibility criteria. The ABI version of the running
+    Geany and the one that's compiled into the plugin must match exactly (==). In case of mismatch,
+    the affected plugins need to be recompiled (generally without source code changes) against the
+    running Geany. The ABI is usually stable even across multiple releases of Geany.
   - The API version is secondary. It must not match exactly, however the plugin can report
     a minimum API version that it requires to run. Geany will check if its own API is larger than
-    that (>=) and will otherwise refuse to load the plugin.
+    that (>=) and will otherwise refuse to load the plugin. The API version is incremented when
+    functions or variables are added to the API which often happens more than once within a release
+    cycle.
   - The API version the plugin is compiled against is still relevant for enabling compatibility
     code inside Geany (for cases where incrementing the ABI version could be avoided).
 
-Instead of @a geany_plugin_register() it is very highly recommended to use @a GEANY_PLUGIN_REGISTER().
-This is a convenient way to pass Geany's current API and ABI versions without requiring future
-code changes whenever either one changes. In fact, the promise that plugins need to be just
-recompiled on ABI change can hold if the plugins use this macro. You still want to pass the API
-version needed at minimum to run your plugin. The value is defined in
-@a plugindata.h by @a GEANY_API_VERSION. In most cases this should be your minimum.
-Nevertheless when setting this value, you should choose the lowest possible version here to
-make the plugin compatible with a bigger number of versions of Geany.
-The absolute minimum is 225 which introduced the new plugin entry points.
+Instead of calling geany_plugin_register() directly it is very highly recommended to use
+GEANY_PLUGIN_REGISTER(). This is a convenient way to pass Geany's current API and ABI versions
+without requiring future code changes whenever either one changes. In fact, the promise that
+plugins need to be just recompiled on ABI change can hold if the plugins use this macro. You still
+want to pass the API version needed at minimum to run your plugin. The value is defined in
+plugindata.h by @ref GEANY_API_VERSION. In most cases this should be your minimum. Nevertheless when
+setting this value, you should choose the lowest possible version here to make the plugin
+compatible with a bigger number of versions of Geany. The absolute minimum is 225 which introduced
+the new plugin entry points.
 
-To increase your flexibility the API version of the running Geany is passed to @a
-geany_load_module(). You can use this information to toggle API-specific code. This comes handy,
-for example to enable optional code that requires a recent API version without raising your minimum
-required API version. This enables to running the plugin against more Geany versions, although
-perhaps at reduced functionality.
+To increase your flexibility the API version of the running Geany is passed to geany_load_module().
+You can use this information to toggle API-specific code. This comes handy, for example to enable
+optional code that requires a recent API version without raising your minimum required API version.
+This enables running the plugin against more Geany versions, although perhaps at reduced
+functionality.
 
 @subsection example Example
 
@@ -374,13 +382,13 @@ compiler here, for example @c g++.
 
 Let's go on and implement some real functionality.
 
-As mentioned before, @ref GeanyPluginFuncs::init() will be called when the plugin is activated by the user.
-So it should implement everything that needs to be done during startup. In this case,
-we'd like to add a menu item to Geany's Tools menu which runs a dialog printing "Hello World".
+As mentioned before, GeanyPluginFuncs::init() will be called when the plugin is loaded by
+Geany. So it should implement everything that needs to be done during startup. In this case, we'd
+like to add a menu item to Geany's Tools menu which runs a dialog printing "Hello World".
+
 @code
 static gboolean hello_init(GeanyPlugin *plugin, gpointer pdata)
 {
-	GeanyData *geany = plugin->geany_data;
 	GtkWidget *main_menu_item;
 
 	// Create a new menu item and show it
@@ -388,7 +396,7 @@ static gboolean hello_init(GeanyPlugin *plugin, gpointer pdata)
 	gtk_widget_show(main_menu_item);
 
 	// Attach the new menu item to the Tools menu
-	gtk_container_add(GTK_CONTAINER(geany->main_widgets->tools_menu),
+	gtk_container_add(GTK_CONTAINER(plugin->geany_data->main_widgets->tools_menu),
 		main_menu_item);
 
 	// Connect the menu item with a callback function
@@ -400,11 +408,10 @@ static gboolean hello_init(GeanyPlugin *plugin, gpointer pdata)
 }
 @endcode
 
-This will add an item to the Tools menu and connect this item to a function which implements
-what should be done when the menu item is activated by the user.
-This is done by g_signal_connect(). The Tools menu can be accessed with
-plugin->geany-data->main_widgets->tools_menu. The structure @a main_widgets contains pointers to
-the all main GUI elements in Geany.
+This will add an item to the Tools menu and connect this item to a function which implements what
+should be done when the menu item is activated by the user. This is done by g_signal_connect(). The
+Tools menu can be accessed with plugin->geany_data->main_widgets->tools_menu. The structure
+GeanyMainWidgets contains pointers to all main GUI elements in Geany.
 
 Geany has a simple API for showing message dialogs. So our function contains
 only a few lines:
@@ -419,15 +426,14 @@ For the moment you don't need to worry about the parameters of that function.
 
 Now we need to clean up properly when the plugin is unloaded.
 
-To remove the menu item from the Tools menu, you can use gtk_widget_destroy().
-gtk_widget_destroy() expects a pointer to a GtkWidget object.
+To remove the menu item from the Tools menu you can use gtk_widget_destroy().
 
-First you should add gtk_widget_destroy() to your @ref GeanyPluginFuncs::cleanup() function. The
-argument for gtk_widget_destroy() is the widget object you created earlier in @ref
-GeanyPluginFuncs::init(). To be able to access this pointer in GeanyPluginFuncs::cleanup(), you
-need to use geany_plugin_set_data() to set plugin-defined data pointer to the widget.
-Alternatively, you can store the pointer in some global variable so its visibility will increase
-and it can be accessed in all functions.
+First you should add gtk_widget_destroy() to your GeanyPluginFuncs::cleanup() function. The
+argument for gtk_widget_destroy() is the widget object you created earlier in
+GeanyPluginFuncs::init(). To be able to access this pointer in GeanyPluginFuncs::cleanup() you can
+use geany_plugin_set_data() to set plugin-defined data pointer to the widget. Alternatively, you
+can store the pointer in some global variable so its visibility will increase and it can be
+accessed in all functions.
 
 @code
 /* alternative: global variable:
@@ -440,6 +446,7 @@ static gboolean hello_init(GeanyPlugin *plugin, gpointer pdata)
 	gtk_widget_show(main_menu_item);
 // ...
 	geany_plugin_set_data(plugin, main_menu_item, NULL);
+	retrun TRUE;
 }
 
 static void hello_cleanup(GeanyPlugin *plugin, gpointer pdata)
@@ -460,12 +467,19 @@ Once this is done, your first plugin is ready. Congratulations!
 
 #include <geanyplugin.h>
 
+static void item_activate_cb(GtkMenuItem *menuitem, gpointer user_data)
+{
+	dialogs_show_msgbox(GTK_MESSAGE_INFO, "Hello World");
+}
+
+
 static gboolean hello_init(GeanyPlugin *plugin, gpointer pdata)
 {
 	GtkWidget *main_menu_item = gtk_menu_item_new_with_mnemonic("Hello World");
 	gtk_widget_show(main_menu_item);
 
 	geany_plugin_set_data(plugin, main_menu_item, NULL);
+	retrun TRUE;
 }
 
 
@@ -501,12 +515,12 @@ Now you might like to look at Geany's source code for core plugins such as
 
 After having written our first plugin, there is still room for improvement.
 
-By default, geany_load_module() does does not allow translation of the basic plugin
-information for plugins which are not shipped with Geany's core distribution.
-Since most plugins are not shipped with Geany's core, it makes sense to
-enable translation when the plugin is loaded so that it gets translated
-inside Geany's Plugin Manager. The solution is to call the API function
-main_locale_init() inside geany_load_module() and then use gettext's _() as usual.
+By default, @ref geany_load_module() is not prepared to allow translation of the basic plugin
+information, except plugins which are shipped with Geany's core distribution, because custom
+gettext catalogs are not setup. Since most plugins are not shipped with Geany's core, it makes
+sense to setup gettext when the plugin is loaded so that it gets translated inside Geany's Plugin
+Manager. The solution is to call the API function main_locale_init() inside @ref
+geany_load_module() and then use gettext's _() as usual.
 
 The invocation will most probably look similar to this:
 @code
@@ -518,12 +532,7 @@ The invocation will most probably look similar to this:
 	plugin->info->author = "John Doe <john.doe@example.org>";
 @endcode
 
-The @a LOCALEDIR and the @a GETTEXT_PACKAGE parameters are usually set inside the build system.  If
-this has been done, the call for example HelloWorld plugin could look like:
-
-When using this macro, you should use the gettext macro @a _() to mark
-the strings like name and the short description as translatable as well. You
-can see how this is done in the above example.
+The @a LOCALEDIR and the @a GETTEXT_PACKAGE parameters are usually set inside the build system.
 
 As you can see the author's information is not marked as translatable in
 this example.  The community has agreed that the best practice here is to
@@ -533,11 +542,9 @@ native spelling inside parenthesis, where applicable.
 @subsection plugin_i18n Using i18n/l10n inside Plugin
 
 
-You can (and should) also mark other strings beside the plugin's meta
-information as translatable.  Strings used in menu entries, information
-boxes or configuration dialogs should also be translatable as well. To enable this
-use main_locale_init() inside @a funcs->init, if you haven't done already in
-@a geany_load_module()
+You can (and should) also mark other strings beside the plugin's meta information as translatable.
+Strings used in menu entries, information boxes or configuration dialogs should be translatable as
+well.
 
 @code
 static gboolean hello_init(GeanyPlugin *plugin, gpointer pdata)
@@ -548,18 +555,15 @@ static gboolean hello_init(GeanyPlugin *plugin, gpointer pdata)
 }
 @endcode
 
-@note If you already called main_locale_init() in @a geany_load_module() you do not
-need to call it a second time.
-
-@page legacy Legacy Plugin Entry Points and Transition to the Modern ones
+@page legacy Porting guide from legacy entry points to the current ones
 
 @section intro_legacy Introduction
 
 This page briefly describes the deprecated, legacy plugin entry points. These have been in place
-prior to Geany 1.26 and are still loadable for the time being. However, do not create new plugins
-against these. For this reason, the acutal description here is rather minimalistic and concentrates
-on the transition of legacy plugins to the new interface. Basically it's main purpose is to give
-newcomers an idea of what they are looking at if they come across a legacy plugin.
+prior to Geany 1.26 and are still loadable and working for the time being. However, do not create
+new plugins against these. For this reason, the acutal description here is rather minimalistic and
+concentrates on the transition of legacy plugins to the new interface. Basically it's main purpose
+is to give newcomers an idea of what they are looking at if they come across a legacy plugin.
 
 @section overview Overview
 
@@ -570,7 +574,7 @@ Plugin Symbols @endlink.
 
 At the very least plugins must define the functions @a plugin_init(GeanyData *) and @a
 plugin_version_check(gint). Additionally, an instance of the struct PluginInfo named plugin_info
-must be exported as well, this contains the same metadata already known from @ref GeanyPlugin::info. The
+must be exported as well, this contains the same metadata already known from GeanyPlugin::info. The
 functions plugin_cleanup(), plugin_help(), plugin_configure(GtkDialog *) and
 plugin_configure_single(GtkWidget *) are optional, however Geany prints a warning if
 plugin_cleanup() is missing and only one of plugin_configure(GtkDialog *) and
@@ -579,24 +583,28 @@ plugin_configure_single(GtkWidget *) is used for any single plugin.
 By convention, plugin_version_check() is implicitely defined through the use of PLUGIN_VERSION_CHECK(),
 and similarly plugin_info is defined through PLUGIN_SET_INFO() or PLUGIN_SET_TRANSLATABLE_INFO().
 
-The functions should generally perform the same tasks as their eqivalents in @refs GeanyPlugin::funcs.
+The functions should generally perform the same tasks as their eqivalents in GeanyPlugin::funcs.
 
 Geany also recognized numerous variable fields if the plugin exported them globally, and actually
 set a few of them inside the plugins data section.
 
-@section transition Transitioning a Legacy Plugin
+@section transition Porting a Legacy Plugin
 
 Given a legacy plugin it can be modified to use the new entry points without much effort. This
 section gives a basic recipe that should work for most existing plugins. The transition should
-be easy and painless so it is recommended that you switch your plugin as soon as possible.
+be easy and painless so it is recommended that you adapt your plugin as soon as possible.
 
-@subsection functions Functions
-Probably the biggest hurdle is the dropped support of the long-deprecated
-plugin_configure_single(). This means you first have to port the configuration dialog (if any) to
-the combined plugin dialog. While you previously created a custom dialog you now attach the main
-widget of that dialog to the combined plugin dialog simply by returning it from @ref
-GeanyPluginFuncs::configure. You don't actually add it, Geany will do that for you. The pointer
-to the dialog is passed to @a configure simply to allow you to connect to its "response" or "close"
+@note This guide is intentionally minimalistic (in terms of suggested code changes) in order to
+allow adaption to the current entry points as quickly as possible and without a lot effort. It
+should also work even for rather complex plugins comprising multiple source files. On the other hand
+it does not make use of new features such as geany_plugin_set_data().
+
+@subsection functions Functions Probably the biggest hurdle is the dropped support of the
+long-deprecated plugin_configure_single(). This means you first have to port the configuration
+dialog (if any) to the combined plugin dialog. While you previously created a custom dialog you now
+attach the main widget of that dialog to the combined plugin dialog simply by returning it from
+GeanyPluginFuncs::configure. You don't actually add it, Geany will do that for you. The pointer to
+the dialog is passed to @a configure simply to allow you to connect to its "response" or "close"
 signals.
 
 The following lists the function mapping of previous @a plugin_* functions to the new @a
@@ -647,18 +655,18 @@ void geany_load_module(GeanyPlugin *plugin, GModule *module, gint geany_api_vers
 @note Refer to @ref translatable_plugin_information for i18n support for the metadata.
 
 
-The @ref plugin_callbacks array is supported by assigning the @ref GeanyPluginFuncs::callbacks to
+The @ref plugin_callbacks array is supported by assigning the GeanyPluginFuncs::callbacks to
 the array.
 
-@ref plugin_fields is not supported anymore. Use ui_add_document_sensitive() instead. @a
-plugin_key_group_info and @ref plugin_key_group are also not supported anymore. Use
-plugin_set_key_group() and keybindings_set_item() instead.
+@ref plugin_fields is not supported anymore. Use ui_add_document_sensitive() instead.
+@ref PLUGIN_KEY_GROUP and @ref plugin_key_group are also not supported anymore. Use
+plugin_set_key_group() and keybindings_set_item() respectively.
 
-Additionally, Geany tradionionally set a few variables. This is not the case anymore. @ref
+Additionally, Geany traditionally set a few variables. This is not the case anymore. @ref
 geany_functions has been removed in 1.25 and since then existed only for compatibility and has been
 empty. You can simply remove its declaration from your source code. @ref geany_plugin is passed to
-each @ref GeanyPluginFuncs function. You need to store it yourself somewhere if you need it elsewhere. @ref
-geany_data is now available as a member of GeanyPlugin.
+each @ref GeanyPluginFuncs function. You need to store it yourself somewhere if you need it
+elsewhere. @ref geany_data is now available as a member of GeanyPlugin.
 
 @code
 GeanyPlugin *geany_plugin;
@@ -673,8 +681,8 @@ static gboolean my_init(GeanyPlugin *plugin, gpointer pdata)
 }
 @endcode
 
-@ref geany_plugin is also passed by default to the PluginCallback signal handlers as data pointer if
-it's set to NULL.
+@ref geany_plugin is now also passed by default to the PluginCallback signal handlers as data
+pointer if it's set to NULL.
 
 @code
 PluginCallback plugin_callbacks[] = {
@@ -682,7 +690,7 @@ PluginCallback plugin_callbacks[] = {
 // ...
 };
 
-static gboolean ht_editor_notify_cb(GObject *object, GeanyEditor *editor,
+static gboolean on_editor_notify_cb(GObject *object, GeanyEditor *editor,
 									SCNotification *nt, gpointer data)
 {
 	GeanyPlugin *plugin = data;

--- a/doc/plugins.dox
+++ b/doc/plugins.dox
@@ -5,6 +5,7 @@
  * Copyright 2008-2011 Nick Treleaven <nick(dot)treleaven(at)btinternet(dot)com>
  * Copyright 2009-2012 Frank Lanitz <frank(at)frank(dot)uvena(dot)de>
  * Copyright 2014 Matthew Brush <matt(at)geany(dot)org>
+ * Copyright 2015 Thomas Martitz <kugel(at)rockbox(dot)org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -39,7 +40,7 @@ We will try to document as many functions and structs as possible.
 
 @section pluginsupport Plugin Support
 - @link howto Plugin HowTo @endlink - get started
-- @link pluginsymbols.c Plugin Symbols @endlink
+- @link legacy Legacy Plugin Entry Points and Transition to the Modern ones @endlink
 - @link plugindata.h Plugin Datatypes and Macros @endlink
 - @link pluginsignals.c Plugin Signals @endlink
 - @link pluginutils.h Plugin Utility Functions @endlink
@@ -170,13 +171,21 @@ Geany's website at http://www.geany.org/Support/BuildingOnWin32.
 
 @section helloworld "Hello World"
 
-When writing a plugin, you will find a couple of functions or macros which are mandatory
-and some which are free to use for implementing some useful feature once your plugin
-becomes more powerful like including a configuration or help dialog.
+@note This section describes the new entry points for plugins introduced with Geany 1.26. A short
+summary of the legacy entry points is given at page @ but it should not be used any more.
+
+When writing a plugin, you will find a couple of functions which are mandatory and some which are
+free to use for implementing some useful feature once your plugin becomes more powerful like
+including a configuration or help dialog.
+
+@subsection beginning Beginnings of any Plugin
 
 You should start your plugin with including some of the needed C header files and defining
 some basic global variables which will help you to access all needed functions of the plugin
 API in a more comfortable way.
+
+Please also do not forget about license headers which are by convention at the start of source
+files. You can use templates provided by Geany to get started.
 
 Let's start with the very basic headers and add more later if necessary.
 @code
@@ -186,59 +195,143 @@ Let's start with the very basic headers and add more later if necessary.
 @a geanyplugin.h includes all of the Geany API and also the necessary GTK header files,
 so there is no need to include @a gtk/gtk.h yourself.
 
-@note
-@a plugindata.h contains the biggest part of the plugin API and provides some basic macros.
-
-Then you should define two basic variables which will give access to data fields
-provided by the plugin API.
-@code
-GeanyPlugin			*geany_plugin;
-GeanyData			*geany_data;
-@endcode
+@note @a plugindata.h contains the biggest part of the plugin API and provides some basic macros.
 
 Now you can go on and write your first lines for your new plugin. As mentioned before,
-you will need to implement and fill out a couple of functions/macros to make the plugin work.
-So let's start with PLUGIN_VERSION_CHECK().
+you will need to implement and a couple of functions. Arguably the most important
+one is @a geany_load_module(). This is the function that makes Geany see you plugin at all. When
+Geany scans the pre-defined and user-configured plugin directories, it will take a look at each
+shared library (or DLL on Windows) to see if it exports a @a geany_load_module() symbol. Files
+lacking these will be outright ignored.
 
-PLUGIN_VERSION_CHECK() is a convenient way to tell Geany which version of Geany's plugin API
-is needed at minimum to run your plugin. The value is defined in
+@subsection register Registering a Plugin
+
+Geany will then invoke this function, always and regardless of whether the user activates your
+plugin. In fact its purpose to probe if the plugin should even be presented to the user. Therefore
+it important that you use this function to register your plugin, making it available to the user.
+Geany will pass a pointer to a GeanyPlugin instance which acts as a unique handle to your plugin.
+Use this pointer for registering and later API calls. Registering the plugin consists of a number
+of steps:
+
+  1. Filling GeanyPlugin::info with metadata
+    - @ref PluginInfo::name : The name of your plugin
+    - @ref PluginInfo::description : A brief description.
+    - @ref PluginInfo::version : The current version.
+    - @ref PluginInfo::author : Your contanct information.
+    .
+    Filling all of them is recommended to provide the best user experience, but only the name is truly
+    mandatory.
+  2. Filling GeanyPlugin::funcs with function pointers
+    - @ref GeanyPluginFuncs::init : an initialization function
+    - @ref GeanyPluginFuncs::cleanup : a finalization function
+    - @ref GeanyPluginFuncs::configure : a function that provides configuration (optional)
+    - @ref GeanyPluginFuncs::help : a function that provides help (optional)
+    - @ref GeanyPluginFuncs::callbacks : a pointer to an array of PluginCallback (optional).
+    .
+    @a init and @a cleanup are mandatory, the other ones depend on how advanced your plugin is.
+    Furthermore, the @a init and @a cleanup
+    pair is called when the user activates your plugin in the Plugin Manager. So use these to
+    do advanced initialization and teardown as to not waste resources when the plugin is not even
+    enabled.
+  3. Registering for real by calling @a geany_plugin_register(). You must pass the GeanyPlugin
+    pointer that your received and filled out as above. geany_plugin_register() also takes
+    various version numbers which are detailed below. Please <b>use the macro @a
+    GEANY_PLUGIN_REGISTER()</b> where you only specify the minimum API version. Please also
+    <b>observer the return value</b> of geany_plugin_register(). Geany may refuse to load your
+    plugin due to incompatibilities, you should then abort any extra setup.
+  4. Optionally setting user data that is passed to GeanyPlugin::funcs with geany_plugin_set_data().
+    Here you can set a data pointer that is passed back to your functions called by Geany. This
+    allows to avoid global variables which may be useful. It also allows to set instance pointer
+    to objects in case your plugin isn't written in pure C, enabling you to use member functions
+    as plugin functions.
+    You may also call this function later on, for example in your @ref GeanyPluginFuncs::init
+    routine to defer costly allocations to when the plugin is actually activated by the user.
+
+
+@subsection versions On API and ABI Versions
+As previously mentioned @a geany_plugin_register() takes a number of versions as arguments:
+  1. api_version
+  2. min_api_version
+  3. abi_version
+
+These refer to Geany's versioning scheme to manage plugin compatibility. It follows conrete rules:
+  - Plugins are compiled against a specific Geany version on the build machine at the time of plugin
+    compilation. This version of Geany has specific ABI and API versions, which will be compiled
+    into the plugin.
+  - The Geany version that loads the plugin may be different, possibly even have different API and
+    ABI versions.
+  - The ABI version is primary for plugin compatibility. The ABI version of the running Geany and
+    the one that's compiled into the plugin must match exactly (==). In case of mismatch, the
+    affected plugins generally need to be simply recompiled (without source code changes) against
+    the running Geany.
+  - The API version is secondary. It must not match exactly, however the plugin can report
+    a minimum API version that it requires to run. Geany will check if its own API is larger than
+    that (>=) and will otherwise refuse to load the plugin.
+  - The API version the plugin is compiled against is still relevant for enabling compatibility
+    code inside Geany (for cases where incrementing the ABI version could be avoided).
+
+Instead of @a geany_plugin_register() it is very highly recommended to use @a GEANY_PLUGIN_REGISTER().
+This is a convenient way to pass Geany's current API and ABI versions without requiring future
+code changes whenever either one changes. In fact, the promise that plugins need to be just
+recompiled on ABI change can hold if the plugins use this macro. You still want to pass the API
+version needed at minimum to run your plugin. The value is defined in
 @a plugindata.h by @a GEANY_API_VERSION. In most cases this should be your minimum.
 Nevertheless when setting this value, you should choose the lowest possible version here to
 make the plugin compatible with a bigger number of versions of Geany.
+The absolute minimum is 225 which introduced the new plugin entry points.
 
-For the next step, you will need to tell Geany some basic information about your plugin
-which will be shown in the plugin manager dialog.
+To increase your flexibility the API version of the running Geany is passed to @a
+geany_load_module(). You can use this information to toggle API-specific code. This comes handy,
+for example to enable optional code that requires a recent API version without raising your minimum
+required API version. This enables to running the plugin against more Geany versions, although
+perhaps at reduced functionality.
 
-To do this you should use the PLUGIN_SET_INFO() macro, which expects 4 parameters:
-- Plugin name
-- Short description
-- Version
-- Author
+@subsection example Example
 
-Based on this, the line could look like:
+Going back to our "Hello World" plugin here is example code that properly adds the HelloWorld
+plugin to Geany.
+
 @code
-PLUGIN_SET_INFO("HelloWorld", "Just another tool to say hello world",
-				"1.0", "John Doe <john.doe@example.org>");
-@endcode
+/* License blob */
 
-Once this is done, you will need to implement the function which will be executed when the
-plugin is loaded. Part of that function could be adding and removing of an item to
-Geany's Tools menu, setting up keybindings or registering some callbacks. Also you will
-need to implement the function that is called when your plugin is unloaded.
-These functions are called plugin_init() and plugin_cleanup(). Let's see what this
-looks like:
-@code
-PLUGIN_VERSION_CHECK(211)
+#include <geanyplugin.h>
 
-PLUGIN_SET_INFO("HelloWorld", "Just another tool to say hello world",
-				"1.0", "Joe Doe <joe.doe@example.org>");
 
-void plugin_init(GeanyData *data)
+static gboolean hello_init(GeanyPlugin *plugin, gpointer pdata)
 {
+	printf("Hello World from plugin!\n");
+
+	/* Perform advanced set up here */
+
+	return TRUE;
 }
 
-void plugin_cleanup(void)
+
+static void hello_cleanup(GeanyPlugin *plugin, gpointer pdata)
 {
+	printf("Bye World :-(\n");
+}
+
+
+G_MODULE_EXPORT
+void geany_load_module(GeanyPlugin *plugin, GModule *module, gint geany_api_version)
+{
+	/* Step 1: Set metadata */
+	plugin->info->name = "HelloWorld";
+	plugin->info->description = "Just another tool to say hello world";
+	plugin->info->version = "1.0";
+	plugin->info->author = "John Doe <john.doe@example.org>";
+
+	/* Step 2: Set functions */
+	plugin->funcs->init = hello_init;
+	plugin->funcs->cleanup = hello_cleanup;
+
+	/* Step 3: Register! */
+	if (GEANY_PLUGIN_REGISTER(plugin, 225))
+		return;
+
+	/* Step 4: call geany_plugin_set_data(), not done here
+	geany_plugin_set_data(plugin, data, free_func); */
 }
 @endcode
 
@@ -246,21 +339,20 @@ If you think this plugin seems not to implement any functionality right now and 
 some memory, you are right. But it should compile and load/unload in Geany nicely.
 Now you have the very basic layout of a new plugin. Great, isn't it?
 
-@note
-
-If you would rather write the plugin in C++, you can do that by marking the
-plugin functions that it implements as @c extern @c "C", for example:
+If you would rather write the plugin in C++, you can do that by marking @a geany_load_module()
+as <c> extern "C" </c>, for example:
 
 @code
 
-extern "C" void plugin_init(GeanyData *data)
+extern "C" void geany_load_module(GeanyPlugin *plugin, GModule *module, gint geany_api_version)
 {
 }
 
-extern "C" void plugin_cleanup(void)
-{
-}
 @endcode
+
+You can also create an instance of a class and set that as data pointer (with
+geany_plugin_set_data()). With small wrappers that shuffle the parameters you can even use member
+functions for @ref GeanyPlugin::funcs etc.
 
 @section building Building
 
@@ -275,8 +367,6 @@ Then make the plugin library plugin.so (or plugin.dll on Windows):
 If all went OK, put the library into one of the paths Geany looks for plugins,
 e.g. $prefix/lib/geany. See @ref paths "Installation paths" for details.
 
-@note
-
 If you are writing the plugin in C++, then you will need to use your C++
 compiler here, for example @c g++.
 
@@ -284,12 +374,13 @@ compiler here, for example @c g++.
 
 Let's go on and implement some real functionality.
 
-As mentioned before, plugin_init() will be called when the plugin is loaded in Geany.
+As mentioned before, @ref GeanyPluginFuncs::init() will be called when the plugin is activated by the user.
 So it should implement everything that needs to be done during startup. In this case,
 we'd like to add a menu item to Geany's Tools menu which runs a dialog printing "Hello World".
 @code
-void plugin_init(GeanyData *data)
+static gboolean hello_init(GeanyPlugin *plugin, gpointer pdata)
 {
+	GeanyData *geany = plugin->geany_data;
 	GtkWidget *main_menu_item;
 
 	// Create a new menu item and show it
@@ -304,19 +395,21 @@ void plugin_init(GeanyData *data)
 	// which is called when the item is clicked
 	g_signal_connect(main_menu_item, "activate",
 		G_CALLBACK(item_activate_cb), NULL);
+
+	return TRUE;
 }
 @endcode
 
 This will add an item to the Tools menu and connect this item to a function which implements
 what should be done when the menu item is activated by the user.
 This is done by g_signal_connect(). The Tools menu can be accessed with
-geany->main_widgets->tools_menu. The structure @a main_widgets contains pointers to the
-main GUI elements in Geany.
+plugin->geany-data->main_widgets->tools_menu. The structure @a main_widgets contains pointers to
+the all main GUI elements in Geany.
 
 Geany has a simple API for showing message dialogs. So our function contains
 only a few lines:
 @code
-void item_activate_cb(GtkMenuItem *menuitem, gpointer user_data)
+static void item_activate_cb(GtkMenuItem *menuitem, gpointer user_data)
 {
 	dialogs_show_msgbox(GTK_MESSAGE_INFO, "Hello World");
 }
@@ -329,24 +422,30 @@ Now we need to clean up properly when the plugin is unloaded.
 To remove the menu item from the Tools menu, you can use gtk_widget_destroy().
 gtk_widget_destroy() expects a pointer to a GtkWidget object.
 
-First you should add gtk_widget_destroy() to your plugin_cleanup() function.
-The argument for gtk_widget_destroy() is the widget object you created earlier in
-plugin_init(). To be able to access this pointer in plugin_cleanup(), you need to move
-its definition from plugin_init() into the global context so its visibility will increase
+First you should add gtk_widget_destroy() to your @ref GeanyPluginFuncs::cleanup() function. The
+argument for gtk_widget_destroy() is the widget object you created earlier in @ref
+GeanyPluginFuncs::init(). To be able to access this pointer in GeanyPluginFuncs::cleanup(), you
+need to use geany_plugin_set_data() to set plugin-defined data pointer to the widget.
+Alternatively, you can store the pointer in some global variable so its visibility will increase
 and it can be accessed in all functions.
-@code
-static GtkWidget *main_menu_item = NULL;
 
+@code
+/* alternative: global variable:
+static GtkWidget *main_menu_item;
+*/
 // ...
-void plugin_init(GeanyData *data)
+static gboolean hello_init(GeanyPlugin *plugin, gpointer pdata)
 {
-	main_menu_item = gtk_menu_item_new_with_mnemonic("Hello World");
+	GtkWidget *main_menu_item = gtk_menu_item_new_with_mnemonic("Hello World");
 	gtk_widget_show(main_menu_item);
 // ...
+	geany_plugin_set_data(plugin, main_menu_item, NULL);
 }
 
-void plugin_cleanup(void)
+static void hello_cleanup(GeanyPlugin *plugin, gpointer pdata)
 {
+	GtkWidget *main_menu_item = (GtkWidget *) pdata;
+// ...
 	gtk_widget_destroy(main_menu_item);
 }
 @endcode
@@ -358,77 +457,69 @@ Once this is done, your first plugin is ready. Congratulations!
 @section listing Complete listing (without comments)
 
 @code
+
 #include <geanyplugin.h>
 
-GeanyPlugin		*geany_plugin;
-GeanyData		*geany_data;
-
-PLUGIN_VERSION_CHECK(211)
-
-PLUGIN_SET_INFO("HelloWorld", "Just another tool to say hello world",
-				"1.0", "John Doe <john.doe@example.org>");
-
-
-static GtkWidget *main_menu_item = NULL;
-
-static void item_activate_cb(GtkMenuItem *menuitem, gpointer gdata)
+static gboolean hello_init(GeanyPlugin *plugin, gpointer pdata)
 {
-	dialogs_show_msgbox(GTK_MESSAGE_INFO, "Hello World");
-}
-
-void plugin_init(GeanyData *data)
-{
-	main_menu_item = gtk_menu_item_new_with_mnemonic("Hello World");
+	GtkWidget *main_menu_item = gtk_menu_item_new_with_mnemonic("Hello World");
 	gtk_widget_show(main_menu_item);
-	gtk_container_add(GTK_CONTAINER(geany->main_widgets->tools_menu),
-		main_menu_item);
-	g_signal_connect(main_menu_item, "activate",
-		G_CALLBACK(item_activate_cb), NULL);
+
+	geany_plugin_set_data(plugin, main_menu_item, NULL);
 }
 
-void plugin_cleanup(void)
+
+static void hello_cleanup(GeanyPlugin *plugin, gpointer pdata)
 {
+	GtkWidget *main_menu_item = (GtkWidget *) pdata;
+
 	gtk_widget_destroy(main_menu_item);
 }
- @endcode
+
+
+G_MODULE_EXPORT
+void geany_load_module(GeanyPlugin *plugin, GModule *module, gint geany_api_version)
+{
+	plugin->info->name = "HelloWorld";
+	plugin->info->description = "Just another tool to say hello world";
+	plugin->info->version = "1.0";
+	plugin->info->author = "John Doe <john.doe@example.org>";
+
+	plugin->funcs->init = hello_init;
+	plugin->funcs->cleanup = hello_cleanup;
+
+	GEANY_PLUGIN_REGISTER(plugin, 225);
+}
+@endcode
 
 
 Now you might like to look at Geany's source code for core plugins such as
 @a plugins/demoplugin.c.
 
-@section furtherimprovements Furter Improvements and next steps
+@section furtherimprovements Further Improvements and next steps
 @subsection translatable_plugin_information Translatable plugin information
 
 After having written our first plugin, there is still room for improvement.
 
-By default, PLUGIN_SET_INFO() does not allow translation of the basic plugin
+By default, geany_load_module() does does not allow translation of the basic plugin
 information for plugins which are not shipped with Geany's core distribution.
 Since most plugins are not shipped with Geany's core, it makes sense to
 enable translation when the plugin is loaded so that it gets translated
-inside Geany's Plugin Manager.  As of Geany 0.19, the plugin API contains
-the PLUGIN_SET_TRANSLATABLE_INFO() macro which enables translation of the
-basic plugin details passed to PLUGIN_SET_INFO() when the plugin is loaded.
+inside Geany's Plugin Manager. The solution is to call the API function
+main_locale_init() inside geany_load_module() and then use gettext's _() as usual.
 
-PLUGIN_SET_TRANSLATABLE_INFO() takes two more parameters than PLUGIN_SET_INFO(),
-for a total of six parameters.
-
- - Localedir
- - Gettextpackage
- - Plugin name
- - Short description
- - Version
- - Author
-
-The @a Localdir and the @a Gettextpackage parameters are usually set inside
-the build system.  If this has been done, the call for example HelloWorld
-plugin could look like:
-
+The invocation will most probably look similar to this:
 @code
-PLUGIN_SET_TRANSLATABLE_INFO(
-	LOCALEDIR, GETTEXT_PACKAGE, _("Hello World"),
-	_("Just another tool to say hello world"),
-	"1.0", "John Doe <john.doe@example.org>");
+// ...
+	main_locale_init(LOCALEDIR, GETTEXT_PACKAGE);
+	plugin->info->name = _("HelloWorld");
+	plugin->info->description = _("Just another tool to say hello world");
+	plugin->info->version = "1.0";
+	plugin->info->author = "John Doe <john.doe@example.org>";
 @endcode
+
+The @a LOCALEDIR and the @a GETTEXT_PACKAGE parameters are usually set inside the build system.  If
+this has been done, the call for example HelloWorld plugin could look like:
 
 When using this macro, you should use the gettext macro @a _() to mark
 the strings like name and the short description as translatable as well. You
@@ -444,30 +535,170 @@ native spelling inside parenthesis, where applicable.
 
 You can (and should) also mark other strings beside the plugin's meta
 information as translatable.  Strings used in menu entries, information
-boxes or configuration dialogs should also be translatable as well.  Geany
-offers a way to enable this in the plugin's code using the main_locale_init()
-function provided by the plugin API. This function takes the same two
-parameters discussed in the previous section; @a GETTEXT_PACKAGE and
-@a LOCALEDIR.
+boxes or configuration dialogs should also be translatable as well. To enable this
+use main_locale_init() inside @a funcs->init, if you haven't done already in
+@a geany_load_module()
 
-The main_locale_init() function is best called during initialization in the
-plugin's plugin_init() function.  Adding this to the HelloWorld example could
-look like:
 @code
-void plugin_init(GeanyData *data)
+static gboolean hello_init(GeanyPlugin *plugin, gpointer pdata)
 {
 	main_locale_init(LOCALEDIR, GETTEXT_PACKAGE);
-	main_menu_item = gtk_menu_item_new_with_mnemonic("Hello World");
-	gtk_widget_show(main_menu_item);
-	gtk_container_add(GTK_CONTAINER(geany->main_widgets->tools_menu),
-		main_menu_item);
-	g_signal_connect(main_menu_item, "activate",
-		G_CALLBACK(item_activate_cb), NULL);
+	main_menu_item = gtk_menu_item_new_with_mnemonic(_("Hello World"));
+// ...
 }
 @endcode
 
-@note If you've previously called the PLUGIN_SET_TRANSLATABLE_INFO() you do not
-need to call main_locale_init() yourself, as this has been already been
-done for you.
+@note If you already called main_locale_init() in @a geany_load_module() you do not
+need to call it a second time.
+
+@page legacy Legacy Plugin Entry Points and Transition to the Modern ones
+
+@section intro_legacy Introduction
+
+This page briefly describes the deprecated, legacy plugin entry points. These have been in place
+prior to Geany 1.26 and are still loadable for the time being. However, do not create new plugins
+against these. For this reason, the acutal description here is rather minimalistic and concentrates
+on the transition of legacy plugins to the new interface. Basically it's main purpose is to give
+newcomers an idea of what they are looking at if they come across a legacy plugin.
+
+@section overview Overview
+
+The legacy entry points consist of a number of pre-defined symbols (functions and variables)
+exported by plugins. There is no active registration procedure. It is implicit simply by exporting
+the mandatory symbols. The entirety of the symbols is described at the page @link pluginsymbols.c
+Plugin Symbols @endlink.
+
+At the very least plugins must define the functions @a plugin_init(GeanyData *) and @a
+plugin_version_check(gint). Additionally, an instance of the struct PluginInfo named plugin_info
+must be exported as well, this contains the same metadata already known from @ref GeanyPlugin::info. The
+functions plugin_cleanup(), plugin_help(), plugin_configure(GtkDialog *) and
+plugin_configure_single(GtkWidget *) are optional, however Geany prints a warning if
+plugin_cleanup() is missing and only one of plugin_configure(GtkDialog *) and
+plugin_configure_single(GtkWidget *) is used for any single plugin.
+
+By convention, plugin_version_check() is implicitely defined through the use of PLUGIN_VERSION_CHECK(),
+and similarly plugin_info is defined through PLUGIN_SET_INFO() or PLUGIN_SET_TRANSLATABLE_INFO().
+
+The functions should generally perform the same tasks as their eqivalents in @refs GeanyPlugin::funcs.
+
+Geany also recognized numerous variable fields if the plugin exported them globally, and actually
+set a few of them inside the plugins data section.
+
+@section transition Transitioning a Legacy Plugin
+
+Given a legacy plugin it can be modified to use the new entry points without much effort. This
+section gives a basic recipe that should work for most existing plugins. The transition should
+be easy and painless so it is recommended that you switch your plugin as soon as possible.
+
+@subsection functions Functions
+Probably the biggest hurdle is the dropped support of the long-deprecated
+plugin_configure_single(). This means you first have to port the configuration dialog (if any) to
+the combined plugin dialog. While you previously created a custom dialog you now attach the main
+widget of that dialog to the combined plugin dialog simply by returning it from @ref
+GeanyPluginFuncs::configure. You don't actually add it, Geany will do that for you. The pointer
+to the dialog is passed to @a configure simply to allow you to connect to its "response" or "close"
+signals.
+
+The following lists the function mapping of previous @a plugin_* functions to the new @a
+GeanyPlugin::funcs. They are semantically the same, however the new functions receive more
+parameters which you may use or not.
+
+  - plugin_init() => GeanyPlugin->funcs->init
+  - plugin_cleanup() => GeanyPlugin->funcs->cleanup
+  - plugin_help() => GeanyPlugin->funcs->help
+  - plugin_configure() => GeanyPlugin->funcs->configure
+
+@note @ref GeanyPluginFuncs::init() should return a boolean value: whether or not the plugin loaded
+succesfully. Since legacy plugins couldn't fail in plugin_init() you should return @c TRUE
+unconditionally.
+
+@note Again, plugin_configure_single() is not supported anymore.
+
+@subsection Variables
+
+Exported global variables are not recognized anymore. They are replaced in the following ways:
+
+@ref plugin_info is simply removed. Instead, you have to assign the values to GeanyPlugin::info
+yourself, and it must be done inside your @a geany_load_module().
+
+Example:
+
+@code
+PLUGIN_SET_INFO(
+	"HelloWorld",
+	"Just another tool to say hello world",
+	"1.0", "John Doe <john.doe@example.org>");
+@endcode
+
+becomes
+
+@code
+G_MODULE_EXPORT
+void geany_load_module(GeanyPlugin *plugin, GModule *module, gint geany_api_version)
+{
+// ...
+	plugin->info->name = "HelloWorld";
+	plugin->info->description = "Just another tool to say hello world";
+	plugin->info->version = "1.0";
+	plugin->info->author = "John Doe <john.doe@example.org>";
+// ...
+}
+@endcode
+@note Refer to @ref translatable_plugin_information for i18n support for the metadata.
+
+
+The @ref plugin_callbacks array is supported by assigning the @ref GeanyPluginFuncs::callbacks to
+the array.
+
+@ref plugin_fields is not supported anymore. Use ui_add_document_sensitive() instead. @a
+plugin_key_group_info and @ref plugin_key_group are also not supported anymore. Use
+plugin_set_key_group() and keybindings_set_item() instead.
+
+Additionally, Geany tradionionally set a few variables. This is not the case anymore. @ref
+geany_functions has been removed in 1.25 and since then existed only for compatibility and has been
+empty. You can simply remove its declaration from your source code. @ref geany_plugin is passed to
+each @ref GeanyPluginFuncs function. You need to store it yourself somewhere if you need it elsewhere. @ref
+geany_data is now available as a member of GeanyPlugin.
+
+@code
+GeanyPlugin *geany_plugin;
+GeanyData *geany_data;
+
+static gboolean my_init(GeanyPlugin *plugin, gpointer pdata)
+{
+// ...
+	geany_plugin = plugin;
+	geany_data = plugin->geany_data;
+	return TRUE;
+}
+@endcode
+
+@ref geany_plugin is also passed by default to the PluginCallback signal handlers as data pointer if
+it's set to NULL.
+
+@code
+PluginCallback plugin_callbacks[] = {
+	{ "editor-notify", (GCallback) &on_editor_notify_cb, FALSE, NULL },
+// ...
+};
+
+static gboolean ht_editor_notify_cb(GObject *object, GeanyEditor *editor,
+									SCNotification *nt, gpointer data)
+{
+	GeanyPlugin *plugin = data;
+//...
+}
+
+
+G_MODULE_EXPORT
+void geany_load_module(GeanyPlugin *plugin, GModule *module, gint geany_api_version)
+{
+// ...
+	plugin->funcs->callbacks = plugin_callbacks;
+// ...
+}
+}
+@endcode
+
 
 */

--- a/doc/pluginsymbols.c
+++ b/doc/pluginsymbols.c
@@ -23,7 +23,12 @@
 
 /**
  * @file pluginsymbols.c
- * Symbols declared from within plugins.
+ * Symbols declared from within plugins, all of this is <b>deprecated</b>.
+ *
+ * @deprecated This is the legacy way of making plugins for Geany. Refer to @ref howto for the
+ * modernized process and @ref legacy to learn how to transition your plugin to that new world.
+ * Meanwhile Geany will still load plugins programmed against this interface (even the items that
+ * are marked deprecated individually such as @ref plugin_fields).
  *
  * Geany looks for these symbols (arrays, pointers and functions) when initializing
  * plugins. Some of them are optional, i.e. they can be omitted; others are required

--- a/doc/pluginsymbols.c
+++ b/doc/pluginsymbols.c
@@ -26,7 +26,7 @@
  * Symbols declared from within plugins, all of this is <b>deprecated</b>.
  *
  * @deprecated This is the legacy way of making plugins for Geany. Refer to @ref howto for the
- * modernized process and @ref legacy to learn how to transition your plugin to that new world.
+ * reworked process and @ref legacy to learn how to port your plugin to that new world.
  * Meanwhile Geany will still load plugins programmed against this interface (even the items that
  * are marked deprecated individually such as @ref plugin_fields).
  *
@@ -111,4 +111,3 @@ void plugin_cleanup();
  * or something else.
  * Can be omitted when not needed. */
 void plugin_help();
-

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -40,7 +40,7 @@ saveactions_la_SOURCES   = saveactions.c
 filebrowser_la_SOURCES   = filebrowser.c
 splitwindow_la_SOURCES   = splitwindow.c
 
-demoplugin_la_CFLAGS    = -DG_LOG_DOMAIN=\""Demoplugin"\"
+demoplugin_la_CFLAGS    = -DG_LOG_DOMAIN=\""Demoplugin"\" -DLOCALEDIR=\""$(LOCALEDIR)"\"
 classbuilder_la_CFLAGS  = -DG_LOG_DOMAIN=\""Classbuilder"\"
 htmlchars_la_CFLAGS     = -DG_LOG_DOMAIN=\""HTMLChars"\"
 export_la_CFLAGS        = -DG_LOG_DOMAIN=\""Export"\"

--- a/plugins/demoplugin.c
+++ b/plugins/demoplugin.c
@@ -43,7 +43,10 @@ static gchar *welcome_text = NULL;
 static gboolean on_editor_notify(GObject *object, GeanyEditor *editor,
 								 SCNotification *nt, gpointer data)
 {
-	GeanyData *geany_data = data;
+	/* Geany passes the plugin's GeanyPlugin pointer as user_data if it did not set
+	 * it explicitely. This is specific to PluginCallbacks. */
+	GeanyPlugin *plugin = data;
+	GeanyData *geany_data = plugin->geany_data;
 
 	/* For detailed documentation about the SCNotification struct, please see
 	 * http://www.scintilla.org/ScintillaDoc.html#Notifications. */
@@ -136,8 +139,6 @@ static gboolean demo_init(GeanyPlugin *plugin, gpointer data)
 	main_menu_item = demo_item;
 
 	welcome_text = g_strdup(_("Hello World!"));
-
-	demo_callbacks[0].user_data = geany_data;
 
 	return TRUE;
 }

--- a/plugins/demoplugin.c
+++ b/plugins/demoplugin.c
@@ -35,29 +35,16 @@
 #include "geanyplugin.h"	/* plugin API, always comes first */
 #include "Scintilla.h"	/* for the SCNotification struct */
 
-
-/* These items are set by Geany before plugin_init() is called. */
-GeanyPlugin		*geany_plugin;
-GeanyData		*geany_data;
-
-
-/* Check that the running Geany supports the plugin API version used below, and check
- * for binary compatibility. */
-PLUGIN_VERSION_CHECK(147)
-
-/* All plugins must set name, description, version and author. */
-PLUGIN_SET_INFO(_("Demo"), _("Example plugin."), "0.1" , _("The Geany developer team"))
-
-
 static GtkWidget *main_menu_item = NULL;
 /* text to be shown in the plugin dialog */
 static gchar *welcome_text = NULL;
 
 
-
 static gboolean on_editor_notify(GObject *object, GeanyEditor *editor,
 								 SCNotification *nt, gpointer data)
 {
+	GeanyData *geany_data = data;
+
 	/* For detailed documentation about the SCNotification struct, please see
 	 * http://www.scintilla.org/ScintillaDoc.html#Notifications. */
 	switch (nt->nmhdr.code)
@@ -78,7 +65,7 @@ static gboolean on_editor_notify(GObject *object, GeanyEditor *editor,
 				GtkWidget *dialog;
 
 				dialog = gtk_message_dialog_new(
-					GTK_WINDOW(geany->main_widgets->window),
+					GTK_WINDOW(geany_data->main_widgets->window),
 					GTK_DIALOG_DESTROY_WITH_PARENT,
 					GTK_MESSAGE_INFO,
 					GTK_BUTTONS_OK,
@@ -99,7 +86,7 @@ static gboolean on_editor_notify(GObject *object, GeanyEditor *editor,
 }
 
 
-PluginCallback plugin_callbacks[] =
+static PluginCallback demo_callbacks[] =
 {
 	/* Set 'after' (third field) to TRUE to run the callback @a after the default handler.
 	 * If 'after' is FALSE, the callback is run @a before the default handler, so the plugin
@@ -114,32 +101,34 @@ static void
 item_activate(GtkMenuItem *menuitem, gpointer gdata)
 {
 	GtkWidget *dialog;
+	GeanyPlugin *plugin = gdata;
+	GeanyData *geany_data = plugin->geany_data;
 
 	dialog = gtk_message_dialog_new(
-		GTK_WINDOW(geany->main_widgets->window),
+		GTK_WINDOW(geany_data->main_widgets->window),
 		GTK_DIALOG_DESTROY_WITH_PARENT,
 		GTK_MESSAGE_INFO,
 		GTK_BUTTONS_OK,
 		"%s", welcome_text);
 	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog),
-		_("(From the %s plugin)"), geany_plugin->info->name);
+		_("(From the %s plugin)"), plugin->info->name);
 
 	gtk_dialog_run(GTK_DIALOG(dialog));
 	gtk_widget_destroy(dialog);
 }
 
 
-/* Called by Geany to initialize the plugin.
- * Note: data is the same as geany_data. */
-void plugin_init(GeanyData *data)
+/* Called by Geany to initialize the plugin */
+static void demo_init(GeanyPlugin *plugin, gpointer data)
 {
 	GtkWidget *demo_item;
+	GeanyData *geany_data = plugin->geany_data;
 
 	/* Add an item to the Tools menu */
 	demo_item = gtk_menu_item_new_with_mnemonic(_("_Demo Plugin"));
 	gtk_widget_show(demo_item);
-	gtk_container_add(GTK_CONTAINER(geany->main_widgets->tools_menu), demo_item);
-	g_signal_connect(demo_item, "activate", G_CALLBACK(item_activate), NULL);
+	gtk_container_add(GTK_CONTAINER(geany_data->main_widgets->tools_menu), demo_item);
+	g_signal_connect(demo_item, "activate", G_CALLBACK(item_activate), plugin);
 
 	/* make the menu item sensitive only when documents are open */
 	ui_add_document_sensitive(demo_item);
@@ -147,10 +136,12 @@ void plugin_init(GeanyData *data)
 	main_menu_item = demo_item;
 
 	welcome_text = g_strdup(_("Hello World!"));
+
+	demo_callbacks[0].user_data = geany_data;
 }
 
 
-/* Callback connected in plugin_configure(). */
+/* Callback connected in demo_configure(). */
 static void
 on_configure_response(GtkDialog *dialog, gint response, gpointer user_data)
 {
@@ -170,13 +161,12 @@ on_configure_response(GtkDialog *dialog, gint response, gpointer user_data)
 	}
 }
 
-
 /* Called by Geany to show the plugin's configure dialog. This function is always called after
- * plugin_init() was called.
+ * demo_init() was called.
  * You can omit this function if the plugin doesn't need to be configured.
  * Note: parent is the parent window which can be used as the transient window for the created
  *       dialog. */
-GtkWidget *plugin_configure(GtkDialog *dialog)
+static GtkWidget *demo_configure(GeanyPlugin *plugin, GtkDialog *dialog, gpointer data)
 {
 	GtkWidget *label, *entry, *vbox;
 
@@ -203,11 +193,30 @@ GtkWidget *plugin_configure(GtkDialog *dialog)
 
 /* Called by Geany before unloading the plugin.
  * Here any UI changes should be removed, memory freed and any other finalization done.
- * Be sure to leave Geany as it was before plugin_init(). */
-void plugin_cleanup(void)
+ * Be sure to leave Geany as it was before demo_init(). */
+static void demo_cleanup(GeanyPlugin *plugin, gpointer data)
 {
-	/* remove the menu item added in plugin_init() */
+	/* remove the menu item added in demo_init() */
 	gtk_widget_destroy(main_menu_item);
 	/* release other allocated strings and objects */
 	g_free(welcome_text);
+}
+
+gboolean geany_load_module(GeanyPlugin *plugin, GModule *module, gint geany_api_version)
+{
+	GeanyPluginFuncs funcs = {
+		.init = demo_init,
+		.configure = demo_configure,
+		.cleanup = demo_cleanup,
+		.callbacks = demo_callbacks,
+	};
+
+	/* main_locale_init() must be called for your package before any localization can be done */
+	main_locale_init(LOCALEDIR, GETTEXT_PACKAGE);
+	plugin->info->name = _("Demo");
+	plugin->info->description = _("Example plugin.");
+	plugin->info->version = "0.3";
+	plugin->info->author =  _("The Geany developer team");
+
+	return geany_plugin_register(plugin, GEANY_API_VERSION, 224, GEANY_API_VERSION, &funcs);
 }

--- a/plugins/demoplugin.c
+++ b/plugins/demoplugin.c
@@ -205,7 +205,7 @@ static void demo_cleanup(GeanyPlugin *plugin, gpointer data)
 	g_free(welcome_text);
 }
 
-void geany_load_module(GeanyPlugin *plugin, GModule *module, gint geany_api_version)
+void geany_load_module(GeanyPlugin *plugin)
 {
 	/* main_locale_init() must be called for your package before any localization can be done */
 	main_locale_init(LOCALEDIR, GETTEXT_PACKAGE);

--- a/plugins/demoplugin.c
+++ b/plugins/demoplugin.c
@@ -207,13 +207,6 @@ static void demo_cleanup(GeanyPlugin *plugin, gpointer data)
 
 void geany_load_module(GeanyPlugin *plugin, GModule *module, gint geany_api_version)
 {
-	GeanyPluginFuncs funcs = {
-		.init = demo_init,
-		.configure = demo_configure,
-		.cleanup = demo_cleanup,
-		.callbacks = demo_callbacks,
-	};
-
 	/* main_locale_init() must be called for your package before any localization can be done */
 	main_locale_init(LOCALEDIR, GETTEXT_PACKAGE);
 	plugin->info->name = _("Demo");
@@ -221,5 +214,11 @@ void geany_load_module(GeanyPlugin *plugin, GModule *module, gint geany_api_vers
 	plugin->info->version = "0.3";
 	plugin->info->author =  _("The Geany developer team");
 
-	geany_plugin_register(plugin, GEANY_API_VERSION, 224, GEANY_API_VERSION, &funcs);
+	plugin->funcs->init = demo_init;
+	plugin->funcs->configure = demo_configure;
+	plugin->funcs->help = NULL; /* This demo has no help but it is an option */
+	plugin->funcs->cleanup = demo_cleanup;
+	plugin->funcs->callbacks = demo_callbacks;
+
+	GEANY_PLUGIN_REGISTER(plugin, 224);
 }

--- a/plugins/demoplugin.c
+++ b/plugins/demoplugin.c
@@ -119,7 +119,7 @@ item_activate(GtkMenuItem *menuitem, gpointer gdata)
 
 
 /* Called by Geany to initialize the plugin */
-static void demo_init(GeanyPlugin *plugin, gpointer data)
+static gboolean demo_init(GeanyPlugin *plugin, gpointer data)
 {
 	GtkWidget *demo_item;
 	GeanyData *geany_data = plugin->geany_data;
@@ -138,6 +138,8 @@ static void demo_init(GeanyPlugin *plugin, gpointer data)
 	welcome_text = g_strdup(_("Hello World!"));
 
 	demo_callbacks[0].user_data = geany_data;
+
+	return TRUE;
 }
 
 
@@ -202,7 +204,7 @@ static void demo_cleanup(GeanyPlugin *plugin, gpointer data)
 	g_free(welcome_text);
 }
 
-gboolean geany_load_module(GeanyPlugin *plugin, GModule *module, gint geany_api_version)
+void geany_load_module(GeanyPlugin *plugin, GModule *module, gint geany_api_version)
 {
 	GeanyPluginFuncs funcs = {
 		.init = demo_init,
@@ -218,5 +220,5 @@ gboolean geany_load_module(GeanyPlugin *plugin, GModule *module, gint geany_api_
 	plugin->info->version = "0.3";
 	plugin->info->author =  _("The Geany developer team");
 
-	return geany_plugin_register(plugin, GEANY_API_VERSION, 224, GEANY_API_VERSION, &funcs);
+	geany_plugin_register(plugin, GEANY_API_VERSION, 224, GEANY_API_VERSION, &funcs);
 }

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -237,12 +237,15 @@ GeanyData;
 
 #define geany			geany_data	/**< Simple macro for @c geany_data that reduces typing. */
 
+typedef struct GeanyPluginFuncs GeanyPluginFuncs;
+
 /** Basic information for the plugin and identification.
  * @see geany_plugin. */
 typedef struct GeanyPlugin
 {
 	PluginInfo	*info;	/**< Fields set in plugin_set_info(). */
 	GeanyData	*geany_data;	/**< Pointer to global GeanyData intance */
+	GeanyPluginFuncs *funcs;	/**< Functions implemented by the plugin, set in geany_load_module() */
 
 	struct GeanyPluginPrivate *priv;	/* private */
 }
@@ -277,7 +280,7 @@ void geany_load_module(GeanyPlugin *plugin, GModule *module, gint geany_api_vers
  *
  * @since 1.26
  **/
-typedef struct GeanyPluginFuncs
+struct GeanyPluginFuncs
 {
 	/** Array of plugin-provided signal handlers @see PluginCallback */
 	PluginCallback *callbacks;
@@ -289,12 +292,20 @@ typedef struct GeanyPluginFuncs
 	void        (*help)      (GeanyPlugin *plugin, gpointer pdata);
 	/** Called when the plugin is disabled or when Geany exits (must not be @c NULL) */
 	void        (*cleanup)   (GeanyPlugin *plugin, gpointer pdata);
-}
-GeanyPluginFuncs;
+};
 
-gboolean geany_plugin_register(GeanyPlugin *plugin, gint api_version, gint min_api_version,
-                               gint abi_version, GeanyPluginFuncs *cbs);
-void geany_plugin_set_data(GeanyPlugin *plugin, gpointer data, GDestroyNotify destroy_notify);
+gboolean geany_plugin_register(GeanyPlugin *plugin, gint api_version,
+                               gint min_api_version, gint abi_version);
+void geany_plugin_set_data(GeanyPlugin *plugin, gpointer data, GDestroyNotify free_func);
+
+/** Convinience macro to register a plugin.
+ *
+ * It simply calls geany_plugin_register() with GEANY_API_VERSION and GEANY_ABI_VERSION.
+ *
+ * @since 1.26
+ * */
+#define GEANY_PLUGIN_REGISTER(plugin, min_api_version) \
+	geany_plugin_register((plugin), GEANY_API_VERSION, (min_api_version), GEANY_ABI_VERSION)
 
 /* Deprecated aliases */
 #ifndef GEANY_DISABLE_DEPRECATED

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -285,14 +285,11 @@ void plugin_cleanup(void);
  * For all glory details please read @ref howto.
  *
  * @param plugin The unique plugin handle to your plugin. You must set some fields here.
- * @param module The GModule associated with your plugin library.
- * @param geany_api_version The API version exposed by the Geany instance that loads your plugin.
- *           This probably not the same as the one your plugin was compiled against.
  *
  * @since 1.26 (API 225)
  * @see @ref howto
  */
-void geany_load_module(GeanyPlugin *plugin, GModule *module, gint geany_api_version);
+void geany_load_module(GeanyPlugin *plugin);
 
 #endif
 

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -265,6 +265,22 @@ void plugin_configure_single(GtkWidget *parent);
 void plugin_help(void);
 void plugin_cleanup(void);
 
+/** Called by Geany when a plugin library is loaded.
+ *
+ * This is the original entry point. Implement and export this function to be loadable at all.
+ * Then fill in GeanyPlugin::info and GeanyPlugin::funcs of the passed @p plugin. Finally
+ * GEANY_PLUGIN_REGISTER() and specify a minimum supported API version.
+ *
+ * For all glory details please read @ref howto.
+ *
+ * @param plugin The unique plugin handle to your plugin. You must set some fields here.
+ * @param module The GModule associated with your plugin library.
+ * @param geany_api_version The API version exposed by the Geany instance that loads your plugin.
+ *           This probably not the same as the one your plugin was compiled against.
+ *
+ * @since 1.26 (API 225)
+ * @see @ref howto
+ */
 void geany_load_module(GeanyPlugin *plugin, GModule *module, gint geany_api_version);
 
 #endif
@@ -278,9 +294,8 @@ void geany_load_module(GeanyPlugin *plugin, GModule *module, gint geany_api_vers
  * plugin-defined data pointer as well as the corresponding GeanyPlugin instance
  * pointer.
  *
+ * @since 1.26 (API 225)
  * @see @ref howto
- *
- * @since 1.26
  **/
 struct GeanyPluginFuncs
 {
@@ -304,7 +319,8 @@ void geany_plugin_set_data(GeanyPlugin *plugin, gpointer data, GDestroyNotify fr
  *
  * It simply calls geany_plugin_register() with GEANY_API_VERSION and GEANY_ABI_VERSION.
  *
- * @since 1.26
+ * @since 1.26  (API 225)
+ * @see @ref howto
  * */
 #define GEANY_PLUGIN_REGISTER(plugin, min_api_version) \
 	geany_plugin_register((plugin), GEANY_API_VERSION, (min_api_version), GEANY_ABI_VERSION)

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -278,6 +278,8 @@ void geany_load_module(GeanyPlugin *plugin, GModule *module, gint geany_api_vers
  * plugin-defined data pointer as well as the corresponding GeanyPlugin instance
  * pointer.
  *
+ * @see @ref howto
+ *
  * @since 1.26
  **/
 struct GeanyPluginFuncs

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -108,17 +108,6 @@ typedef struct PluginInfo
 PluginInfo;
 
 
-/** Basic information for the plugin and identification.
- * @see geany_plugin. */
-typedef struct GeanyPlugin
-{
-	PluginInfo	*info;	/**< Fields set in plugin_set_info(). */
-
-	struct GeanyPluginPrivate *priv;	/* private */
-}
-GeanyPlugin;
-
-
 /** Sets the plugin name and some other basic information about a plugin.
  *
  * @note If you want some of the arguments to be translated, see @ref PLUGIN_SET_TRANSLATABLE_INFO()
@@ -248,6 +237,16 @@ GeanyData;
 
 #define geany			geany_data	/**< Simple macro for @c geany_data that reduces typing. */
 
+/** Basic information for the plugin and identification.
+ * @see geany_plugin. */
+typedef struct GeanyPlugin
+{
+	PluginInfo	*info;	/**< Fields set in plugin_set_info(). */
+	GeanyData	*geany_data;	/**< Pointer to global GeanyData intance */
+
+	struct GeanyPluginPrivate *priv;	/* private */
+}
+GeanyPlugin;
 
 #ifndef GEANY_PRIVATE
 
@@ -263,7 +262,38 @@ void plugin_configure_single(GtkWidget *parent);
 void plugin_help(void);
 void plugin_cleanup(void);
 
+gboolean geany_load_module(GeanyPlugin *plugin, GModule *module, gint geany_api_version);
+
 #endif
+
+/** Callback functions that need to be implemented for every plugin.
+ *
+ * These callbacks should be registered by the plugin within Geany's call to
+ * geany_load_module() by calling geany_plugin_register() with an instance of this type.
+ *
+ * Geany will then call the callbacks at appropriate times. Each gets passed the
+ * plugin-defined data pointer as well as the corresponding GeanyPlugin instance
+ * pointer.
+ *
+ * @since 1.26
+ **/
+typedef struct GeanyPluginFuncs
+{
+	/** Array of plugin-provided signal handlers @see PluginCallback */
+	PluginCallback *callbacks;
+	/** Called to initialize the plugin, when the user activates it (must not be @c NULL) */
+	void        (*init)      (GeanyPlugin *plugin, gpointer pdata);
+	/** plugins configure dialog, optional (can be @c NULL) */
+	GtkWidget*  (*configure) (GeanyPlugin *plugin, GtkDialog *dialog, gpointer pdata);
+	/** Called when the plugin should show some help, optional (can be @c NULL) */
+	void        (*help)      (GeanyPlugin *plugin, gpointer pdata);
+	/** Called when the plugin is disabled or when Geany exits (must not be @c NULL) */
+	void        (*cleanup)   (GeanyPlugin *plugin, gpointer pdata);
+}
+GeanyPluginFuncs;
+
+gboolean geany_plugin_register(GeanyPlugin *plugin, gint api_version, gint min_api_version,
+                               gint abi_version, GeanyPluginFuncs *cbs, gpointer pdata);
 
 /* Deprecated aliases */
 #ifndef GEANY_DISABLE_DEPRECATED

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -293,7 +293,8 @@ typedef struct GeanyPluginFuncs
 GeanyPluginFuncs;
 
 gboolean geany_plugin_register(GeanyPlugin *plugin, gint api_version, gint min_api_version,
-                               gint abi_version, GeanyPluginFuncs *cbs, gpointer pdata);
+                               gint abi_version, GeanyPluginFuncs *cbs);
+void geany_plugin_set_data(GeanyPlugin *plugin, gpointer data, GDestroyNotify destroy_notify);
 
 /* Deprecated aliases */
 #ifndef GEANY_DISABLE_DEPRECATED

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -262,7 +262,7 @@ void plugin_configure_single(GtkWidget *parent);
 void plugin_help(void);
 void plugin_cleanup(void);
 
-gboolean geany_load_module(GeanyPlugin *plugin, GModule *module, gint geany_api_version);
+void geany_load_module(GeanyPlugin *plugin, GModule *module, gint geany_api_version);
 
 #endif
 
@@ -282,7 +282,7 @@ typedef struct GeanyPluginFuncs
 	/** Array of plugin-provided signal handlers @see PluginCallback */
 	PluginCallback *callbacks;
 	/** Called to initialize the plugin, when the user activates it (must not be @c NULL) */
-	void        (*init)      (GeanyPlugin *plugin, gpointer pdata);
+	gboolean    (*init)      (GeanyPlugin *plugin, gpointer pdata);
 	/** plugins configure dialog, optional (can be @c NULL) */
 	GtkWidget*  (*configure) (GeanyPlugin *plugin, GtkDialog *dialog, gpointer pdata);
 	/** Called when the plugin should show some help, optional (can be @c NULL) */

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -60,6 +60,18 @@ G_BEGIN_DECLS
  */
 #define GEANY_API_VERSION 224
 
+/**
+ * Gets the run-time API version of the Geany core
+ *
+ * @note Unlike GEANY_API_VERSION this version is the value of that
+ * define at the time when Geany itself was compiled. This can be useful
+ * to have "soft" dependencies on Geany features.
+ *
+ * @return The value of GEANY_API_VERSION at Geany's compile time.
+ * @since 1.26
+ */
+gint geany_api_version(void);
+
 /* hack to have a different ABI when built with GTK3 because loading GTK2-linked plugins
  * with GTK3-linked Geany leads to crash */
 #if GTK_CHECK_VERSION(3, 0, 0)
@@ -73,7 +85,6 @@ G_BEGIN_DECLS
 /* This should usually stay the same if fields are only appended, assuming only pointers to
  * structs and not structs themselves are declared by plugins. */
 #define GEANY_ABI_VERSION (71 << GEANY_ABI_SHIFT)
-
 
 /** Defines a function to check the plugin is safe to load.
  * This performs runtime checks that try to ensure:

--- a/src/pluginprivate.h
+++ b/src/pluginprivate.h
@@ -81,6 +81,7 @@ typedef struct GeanyPluginPrivate
 	GList			*sources;				/* GSources to destroy when unloading */
 
 	gpointer		cb_data;				/* user data passed back to functions in GeanyPluginFuncs */
+	GDestroyNotify	cb_data_destroy;		/* called when the plugin is unloaded, for cb_data */
 	LoadedFlags		flags;					/* bit-or of LoadedFlags */
 }
 GeanyPluginPrivate;

--- a/src/pluginprivate.h
+++ b/src/pluginprivate.h
@@ -32,25 +32,12 @@
 
 G_BEGIN_DECLS
 
-typedef struct GeanyData GeanyData;
-
 typedef struct SignalConnection
 {
 	GObject	*object;
 	gulong	handler_id;
 }
 SignalConnection;
-
-typedef struct _GeanyPluginFuncsLegacy
-{
-	void		(*init) (GeanyData *data);			/* Called when the plugin is enabled */
-	GtkWidget*	(*configure) (GtkDialog *dialog);	/* plugins configure dialog, optional */
-	void		(*configure_single) (GtkWidget *parent); /* plugin configure dialog, optional */
-	void		(*help) (void);						/* Called when the plugin should show some help, optional */
-	void		(*cleanup) (void);					/* Called when the plugin is disabled or when Geany exits */
-	void		(*set_info) (PluginInfo *info);		/* Called to let the plugin provide metadata for the PM dialog */
-}
-GeanyPluginFuncsLegacy;
 
 typedef enum _LoadedFlags {
 	LOADED_OK = 0x01,
@@ -65,13 +52,8 @@ typedef struct GeanyPluginPrivate
 	PluginInfo		info;				/* plugin name, description, etc */
 	GeanyPlugin		public;				/* fields the plugin can read */
 
-	union {
-		GeanyPluginFuncs n;					/* new-style callbacks, set by geany_plugin_register()
-											 * NULL for legacy plugins (they do not call
-											 * geany_plugin_register()) */
-		GeanyPluginFuncsLegacy l;			/* old callbacks, complete with set_info(), version_check()
-											 * and configure_single. Deprecated */
-	} cbs;
+	GeanyPluginFuncs cbs;					/* Callbacks set by geany_plugin_register() */
+	void		(*configure_single) (GtkWidget *parent); /* plugin configure dialog, optional and deprecated */
 
 	/* extra stuff */
 	PluginFields	fields;

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -206,8 +206,9 @@ static void add_callbacks(Plugin *plugin, PluginCallback *callbacks)
 	{
 		cb = &callbacks[i];
 
+		/* Pass the plugin as default user_data if none was set by the plugin itself */
 		plugin_signal_connect(&plugin->public, NULL, cb->signal_name, cb->after,
-			cb->callback, cb->user_data);
+			cb->callback, cb->user_data ? cb->user_data : &plugin->public);
 	}
 }
 

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -162,37 +162,26 @@ static Plugin *find_active_plugin_by_name(const gchar *filename)
 }
 
 
+/* Mimics plugin_version_check() of legacy plugins for use with plugin_check_version() below */
+#define PLUGIN_VERSION_CODE(api, abi) ((abi) != GEANY_ABI_VERSION ? -1 : (api))
+
 static gboolean
-plugin_check_version(GModule *module)
+plugin_check_version(Plugin *plugin, int plugin_version_code)
 {
-	gint (*version_check)(gint) = NULL;
-
-	g_module_symbol(module, "plugin_version_check", (void *) &version_check);
-
-	if (G_UNLIKELY(! version_check))
+	GModule *module = plugin->module;
+	if (plugin_version_code < 0)
 	{
-		geany_debug("Plugin \"%s\" has no plugin_version_check() function - ignoring plugin!",
-				g_module_name(module));
+		msgwin_status_add(_("The plugin \"%s\" is not binary compatible with this "
+			"release of Geany - please recompile it."), g_module_name(module));
+		geany_debug("Plugin \"%s\" is not binary compatible with this "
+			"release of Geany - recompile it.", g_module_name(module));
 		return FALSE;
 	}
-	else
+	if (plugin_version_code > GEANY_API_VERSION)
 	{
-		gint result = version_check(GEANY_ABI_VERSION);
-
-		if (result < 0)
-		{
-			msgwin_status_add(_("The plugin \"%s\" is not binary compatible with this "
-				"release of Geany - please recompile it."), g_module_name(module));
-			geany_debug("Plugin \"%s\" is not binary compatible with this "
-				"release of Geany - recompile it.", g_module_name(module));
-			return FALSE;
-		}
-		if (result > GEANY_API_VERSION)
-		{
-			geany_debug("Plugin \"%s\" requires a newer version of Geany (API >= v%d).",
-				g_module_name(module), result);
-			return FALSE;
-		}
+		geany_debug("Plugin \"%s\" requires a newer version of Geany (API >= v%d).",
+			g_module_name(module), plugin_version_code);
+		return FALSE;
 	}
 	return TRUE;
 }
@@ -269,56 +258,160 @@ static gint cmp_plugin_names(gconstpointer a, gconstpointer b)
 }
 
 
-static void
-plugin_load(Plugin *plugin)
+/** Register a plugin to Geany.
+ *
+ * The plugin will show up in the plugin manager. The user can interact with
+ * it based on the callbacks it provides and installed GUI elements.
+ *
+ * The return value must be checked. It may be FALSE if the plugin failed to register which can
+ * mainly happen for two reasons (future Geany versions may add bad conditions):
+ *  - Not all mandatory fields of GeanyPlugin have been set.
+ *  - The ABI or API versions reported by the plugin are incompatible to the running Geany.
+ *
+ * @param plugin The plugin provided by Geany
+ * @param api_version The API version the plugin is compiled against (pass GEANY_API_VERSION)
+ * @param min_api_version The minimum API version required by the plugin
+ * @param abi_version The exact ABI version the plugin is compiled against (pass GEANY_ABI_VERSION)
+ * @param cbs A statically allocated @ref GeanyPluginFuncs structure filled with callbacks
+ * @param pdata A data pointer to store plugin-specific data, will be passed to the plugin's callbacks
+ *
+ * @return TRUE if the plugin was successfully registered. Otherwise FALSE.
+ *
+ * @since 1.26
+ **/
+GEANY_API_SYMBOL
+gboolean geany_plugin_register(GeanyPlugin *plugin, gint api_version, gint min_api_version,
+                               gint abi_version, GeanyPluginFuncs *cbs, gpointer pdata)
 {
-	GeanyPlugin **p_geany_plugin;
-	PluginCallback *callbacks;
-	PluginInfo **p_info;
-	PluginFields **plugin_fields;
+	Plugin *p;
 
-	/* set these symbols before plugin_init() is called
-	 * we don't set geany_data since it is set directly by plugin_new() */
-	g_module_symbol(plugin->module, "geany_plugin", (void *) &p_geany_plugin);
-	if (p_geany_plugin)
-		*p_geany_plugin = &plugin->public;
-	g_module_symbol(plugin->module, "plugin_info", (void *) &p_info);
-	if (p_info)
-		*p_info = &plugin->info;
-	g_module_symbol(plugin->module, "plugin_fields", (void *) &plugin_fields);
-	if (plugin_fields)
-		*plugin_fields = &plugin->fields;
-	read_key_group(plugin);
+	g_return_val_if_fail(plugin != NULL, FALSE);
 
-	/* start the plugin */
-	g_return_if_fail(plugin->init);
-	plugin->init(&geany_data);
+	p = plugin->priv;
+	/* Prevent registering incompatible plugins. */
+	if (! plugin_check_version(p, PLUGIN_VERSION_CODE(api_version, abi_version)))
+		return FALSE;
+	/* If it ever becomes necessary we can save the api version in Plugin
+	 * and apply compat code on a per-plugin basis, because we learn about
+	 * the requested API version here. Also if we add to GeanyPluginFuncs then
+	 * we have to inspect the plugin's api so that we don't misinterpret
+	 * function pointers the plugin doesn't know anything about. */
+	p->cbs.n = *cbs;
+	p->cb_data = pdata;
 
-	/* store some function pointers for later use */
-	g_module_symbol(plugin->module, "plugin_configure", (void *) &plugin->configure);
-	g_module_symbol(plugin->module, "plugin_configure_single", (void *) &plugin->configure_single);
-	if (app->debug_mode && plugin->configure && plugin->configure_single)
-		g_warning("Plugin '%s' implements plugin_configure_single() unnecessarily - "
-			"only plugin_configure() will be used!",
-			plugin->info.name);
-
-	g_module_symbol(plugin->module, "plugin_help", (void *) &plugin->help);
-	g_module_symbol(plugin->module, "plugin_cleanup", (void *) &plugin->cleanup);
-	if (plugin->cleanup == NULL)
+	/* Only init and cleanup callbacks are truly mandatory. */
+	if (! cbs->init || ! cbs->cleanup)
 	{
-		if (app->debug_mode)
+		geany_debug("Plugin '%s' has no %s function - ignoring plugin!",
+				cbs->init ? "cleanup" : "init", g_module_name(p->module));
+	}
+	else
+	{
+		/* Yes, name is checked again later on, however we want return FALSE here
+		 * to signal the error back to the plugin (but we don't print the message twice) */
+		if (! EMPTY(p->info.name))
+			p->flags = LOADED_OK;
+	}
+
+	return PLUGIN_LOADED_OK(p);
+}
+
+
+/* This function is the equivalent of geany_plugin_register() for legacy-style
+ * plugins which we continue to load for the time being. */
+static void register_legacy_plugin(Plugin *plugin, GModule *module)
+{
+	gint (*p_version_check) (gint abi_version);
+	void (*p_set_info) (PluginInfo *info);
+	GeanyData **p_geany_data;
+
+#define CHECK_FUNC(__x, p)                                                                \
+	if (! g_module_symbol(module, "plugin_" #__x, (void *) (p)))                          \
+	{                                                                                     \
+		geany_debug("Plugin \"%s\" has no plugin_" #__x "() function - ignoring plugin!", \
+				g_module_name(plugin->module));                                           \
+		return;                                                                           \
+	}
+	CHECK_FUNC(version_check, &p_version_check);
+	CHECK_FUNC(set_info, &p_set_info);
+	CHECK_FUNC(init, &plugin->cbs.l.init);
+#undef CHECK_FUNC
+
+	/* We must verify the version first. If the plugin has become incompatible any
+	 * further actions should be considered invalid and therefore skipped. */
+	if (! plugin_check_version(plugin, p_version_check(GEANY_ABI_VERSION)))
+		return;
+
+	/* Since the version check passed we can proceed with setting basic fields and
+	 * calling its set_info() (which might want to call Geany functions already). */
+	g_module_symbol(module, "geany_data", (void *) &p_geany_data);
+	if (p_geany_data)
+		*p_geany_data = &geany_data;
+	/* Read plugin name, etc. name is mandatory but that's enforced in the common code. */
+	p_set_info(&plugin->info);
+
+	/* If all went well we can set the remaining callbacks and let it go for good. */
+	g_module_symbol(module, "plugin_configure", (void *) &plugin->cbs.l.configure);
+	g_module_symbol(module, "plugin_configure_single", (void *) &plugin->cbs.l.configure_single);
+	g_module_symbol(module, "plugin_help", (void *) &plugin->cbs.l.help);
+	g_module_symbol(module, "plugin_cleanup", (void *) &plugin->cbs.l.cleanup);
+
+	if (app->debug_mode)
+	{
+		if (plugin->cbs.l.configure && plugin->cbs.l.configure_single)
+			g_warning("Plugin '%s' implements plugin_configure_single() unnecessarily - "
+				"only plugin_configure() will be used!",
+				plugin->info.name);
+		if (plugin->cbs.l.cleanup == NULL)
 			g_warning("Plugin '%s' has no plugin_cleanup() function - there may be memory leaks!",
 				plugin->info.name);
 	}
 
-	/* now read any plugin-owned data that might have been set in plugin_init() */
+	plugin->flags = LOADED_OK | IS_LEGACY;
+}
 
-	if (plugin->fields.flags & PLUGIN_IS_DOCUMENT_SENSITIVE)
+
+static void
+plugin_load(Plugin *plugin)
+{
+	PluginCallback *callbacks;
+
+	if (PLUGIN_IS_LEGACY(plugin))
 	{
-		ui_add_document_sensitive(plugin->fields.menu_item);
+		GeanyPlugin **p_geany_plugin;
+		PluginInfo **p_info;
+		PluginFields **plugin_fields;
+		/* set these symbols before plugin_init() is called
+		 * we don't set geany_data since it is set directly by plugin_new() */
+		g_module_symbol(plugin->module, "geany_plugin", (void *) &p_geany_plugin);
+		if (p_geany_plugin)
+			*p_geany_plugin = &plugin->public;
+		g_module_symbol(plugin->module, "plugin_info", (void *) &p_info);
+		if (p_info)
+			*p_info = &plugin->info;
+		g_module_symbol(plugin->module, "plugin_fields", (void *) &plugin_fields);
+		if (plugin_fields)
+			*plugin_fields = &plugin->fields;
+		read_key_group(plugin);
+
+		/* start the plugin */
+		plugin->cbs.l.init(&geany_data);
+
+		/* now read any plugin-owned data that might have been set in plugin_init() */
+		if (plugin->fields.flags & PLUGIN_IS_DOCUMENT_SENSITIVE)
+		{
+			ui_add_document_sensitive(plugin->fields.menu_item);
+		}
+
+		g_module_symbol(plugin->module, "plugin_callbacks", (void *) &callbacks);
+	}
+	else
+	{
+		plugin->cbs.n.init(&plugin->public, plugin->cb_data);
+		callbacks = plugin->cbs.n.callbacks;
 	}
 
-	g_module_symbol(plugin->module, "plugin_callbacks", (void *) &callbacks);
+	/* new-style plugins set their callbacks in geany_load_module() */
 	if (callbacks)
 		add_callbacks(plugin, callbacks);
 
@@ -327,8 +420,7 @@ plugin_load(Plugin *plugin)
 	 * sorted by plugin name */
 	active_plugin_list = g_list_insert_sorted(active_plugin_list, plugin, cmp_plugin_names);
 
-	geany_debug("Loaded:   %s (%s)", plugin->filename,
-		FALLBACK(plugin->info.name, "<Unknown>"));
+	geany_debug("Loaded:   %s (%s)", plugin->filename, plugin->info.name);
 }
 
 
@@ -342,8 +434,7 @@ plugin_new(const gchar *fname, gboolean load_plugin, gboolean add_to_list)
 {
 	Plugin *plugin;
 	GModule *module;
-	GeanyData **p_geany_data;
-	void (*plugin_set_info)(PluginInfo*);
+	gboolean (*p_geany_load_module)(GeanyPlugin *, GModule *, gint);
 
 	g_return_val_if_fail(fname, NULL);
 	g_return_val_if_fail(g_module_supported(), NULL);
@@ -387,60 +478,42 @@ plugin_new(const gchar *fname, gboolean load_plugin, gboolean add_to_list)
 		return NULL;
 	}
 
-	if (! plugin_check_version(module))
-	{
-		if (! g_module_close(module))
-			g_warning("%s: %s", fname, g_module_error());
-		return NULL;
-	}
-
-	g_module_symbol(module, "plugin_set_info", (void *) &plugin_set_info);
-	if (plugin_set_info == NULL)
-	{
-		geany_debug("No plugin_set_info() defined for \"%s\" - ignoring plugin!", fname);
-
-		if (! g_module_close(module))
-			g_warning("%s: %s", fname, g_module_error());
-		return NULL;
-	}
-
 	plugin = g_new0(Plugin, 1);
-
-	/* set basic fields here to allow plugins to call Geany functions in set_info() */
-	g_module_symbol(module, "geany_data", (void *) &p_geany_data);
-	if (p_geany_data)
-		*p_geany_data = &geany_data;
-
-	/* read plugin name, etc. */
-	plugin_set_info(&plugin->info);
-	if (G_UNLIKELY(EMPTY(plugin->info.name)))
-	{
-		geany_debug("No plugin name set in plugin_set_info() for \"%s\" - ignoring plugin!",
-			fname);
-
-		if (! g_module_close(module))
-			g_warning("%s: %s", fname, g_module_error());
-		g_free(plugin);
-		return NULL;
-	}
-
-	g_module_symbol(module, "plugin_init", (void *) &plugin->init);
-	if (plugin->init == NULL)
-	{
-		geany_debug("Plugin '%s' has no plugin_init() function - ignoring plugin!",
-			plugin->info.name);
-
-		if (! g_module_close(module))
-			g_warning("%s: %s", fname, g_module_error());
-		g_free(plugin);
-		return NULL;
-	}
-	/*geany_debug("Initializing plugin '%s'", plugin->info.name);*/
-
-	plugin->filename = g_strdup(fname);
 	plugin->module = module;
-	plugin->public.info = &plugin->info;
+	plugin->filename = g_strdup(fname);
+	plugin->public.geany_data = &geany_data;
 	plugin->public.priv = plugin;
+	/* Fields of plugin->info must to be initialized by the plugin */
+	plugin->public.info = &plugin->info;
+
+	g_module_symbol(module, "geany_load_module", (void *) &p_geany_load_module);
+	if (p_geany_load_module)
+	{
+		/* This is a new style plugin. It should fill in plugin->info and then call
+		 * geany_plugin_register() in its geany_load_module() to successfully load.
+		 * The ABI and API checks are performed by geany_plugin_register() (i.e. by us).
+		 * We check the LOADED_OK flag separately to protect us against buggy plugins
+		 * who ignore the result of geany_plugin_register() and register anyway */
+		p_geany_load_module(&plugin->public, module, GEANY_API_VERSION);
+	}
+	else
+	{
+		/* This is the legacy / deprecated code path. It does roughly the same as
+		 * geany_load_module() and geany_plugin_register() together for the new ones */
+		register_legacy_plugin(plugin, module);
+	}
+
+	if (! PLUGIN_LOADED_OK(plugin))
+	{
+		geany_debug("Failed to load \"%s\" - ignoring plugin!", fname);
+		goto err;
+	}
+
+	if (EMPTY(plugin->info.name))
+	{
+		geany_debug("No plugin name set for \"%s\" - ignoring plugin!", fname);
+		goto err;
+	}
 
 	if (load_plugin)
 		plugin_load(plugin);
@@ -449,6 +522,13 @@ plugin_new(const gchar *fname, gboolean load_plugin, gboolean add_to_list)
 		plugin_list = g_list_prepend(plugin_list, plugin);
 
 	return plugin;
+
+err:
+	if (! g_module_close(module))
+		g_warning("%s: %s", fname, g_module_error());
+	g_free(plugin->filename);
+	g_free(plugin);
+	return NULL;
 }
 
 
@@ -529,8 +609,11 @@ plugin_cleanup(Plugin *plugin)
 {
 	GtkWidget *widget;
 
-	if (plugin->cleanup)
-		plugin->cleanup();
+	/* With geany_plugin_register() cleanup is mandatory */
+	if (! PLUGIN_IS_LEGACY(plugin))
+		plugin->cbs.n.cleanup(&plugin->public, plugin->cb_data);
+	else if (plugin->cbs.l.cleanup)
+		plugin->cbs.l.cleanup();
 
 	remove_callbacks(plugin);
 	remove_sources(plugin);
@@ -851,7 +934,12 @@ gboolean plugins_have_preferences(void)
 	foreach_list(item, active_plugin_list)
 	{
 		Plugin *plugin = item->data;
-		if (plugin->configure != NULL || plugin->configure_single != NULL)
+		gboolean result;
+		if (! PLUGIN_IS_LEGACY(plugin))
+			result = plugin->cbs.n.configure != NULL;
+		else
+			result = plugin->cbs.l.configure != NULL || plugin->cbs.l.configure_single != NULL;
+		if (result)
 			return TRUE;
 	}
 
@@ -892,17 +980,23 @@ static PluginManagerWidgets pm_widgets;
 
 static void pm_update_buttons(Plugin *p)
 {
-	gboolean is_active = FALSE;
 	gboolean has_configure = FALSE;
 	gboolean has_help = FALSE;
 	gboolean has_keybindings = FALSE;
 
-	if (p != NULL)
+	if (p != NULL && is_active_plugin(p))
 	{
-		is_active = is_active_plugin(p);
-		has_configure = (p->configure || p->configure_single) && is_active;
-		has_help = p->help != NULL && is_active;
-		has_keybindings = p->key_group && p->key_group->plugin_key_count > 0 && is_active;
+		if (PLUGIN_IS_LEGACY(p))
+		{
+			has_configure = p->cbs.l.configure || p->cbs.l.configure_single;
+			has_help = p->cbs.l.help != NULL;
+		}
+		else
+		{
+			has_configure = p->cbs.n.configure != NULL;
+			has_help = p->cbs.n.help != NULL;
+		}
+		has_keybindings = p->key_group && p->key_group->plugin_key_count;
 	}
 
 	gtk_widget_set_sensitive(pm_widgets.configure_button, has_configure);
@@ -1239,8 +1333,13 @@ static void pm_on_plugin_button_clicked(G_GNUC_UNUSED GtkButton *button, gpointe
 		{
 			if (GPOINTER_TO_INT(user_data) == PM_BUTTON_CONFIGURE)
 				plugin_show_configure(&p->public);
-			else if (GPOINTER_TO_INT(user_data) == PM_BUTTON_HELP && p->help != NULL)
-				p->help();
+			else if (GPOINTER_TO_INT(user_data) == PM_BUTTON_HELP)
+			{
+				if (PLUGIN_IS_LEGACY(p))
+					p->cbs.l.help();
+				else
+					p->cbs.n.help(&p->public, p->cb_data);
+			}
 			else if (GPOINTER_TO_INT(user_data) == PM_BUTTON_KEYBINDINGS && p->key_group && p->key_group->plugin_key_count > 0)
 				keybindings_dialog_show_prefs_scroll(p->info.name);
 		}

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -270,9 +270,9 @@ static gint cmp_plugin_names(gconstpointer a, gconstpointer b)
  * at least init() and cleanup() functions must be implemented and set.
  *
  * The return value must be checked. It may be FALSE if the plugin failed to register which can
- * mainly happen for two reasons (future Geany versions may add bad conditions):
+ * mainly happen for two reasons (future Geany versions may add new failure conditions):
  *  - Not all mandatory fields of GeanyPlugin have been set.
- *  - The ABI or API versions reported by the plugin are incompatible to the running Geany.
+ *  - The ABI or API versions reported by the plugin are incompatible with the running Geany.
  *
  * @param plugin The plugin provided by Geany
  * @param api_version The API version the plugin is compiled against (pass GEANY_API_VERSION)
@@ -281,7 +281,7 @@ static gint cmp_plugin_names(gconstpointer a, gconstpointer b)
  *
  * @return TRUE if the plugin was successfully registered. Otherwise FALSE.
  *
- * @since 1.26
+ * @since 1.26 (API 225)
  **/
 GEANY_API_SYMBOL
 gboolean geany_plugin_register(GeanyPlugin *plugin, gint api_version, gint min_api_version,

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -489,7 +489,7 @@ plugin_new(const gchar *fname, gboolean load_plugin, gboolean add_to_list)
 {
 	Plugin *plugin;
 	GModule *module;
-	void (*p_geany_load_module)(GeanyPlugin *, GModule *, gint);
+	void (*p_geany_load_module)(GeanyPlugin *);
 
 	g_return_val_if_fail(fname, NULL);
 	g_return_val_if_fail(g_module_supported(), NULL);
@@ -550,7 +550,7 @@ plugin_new(const gchar *fname, gboolean load_plugin, gboolean add_to_list)
 		 * The ABI and API checks are performed by geany_plugin_register() (i.e. by us).
 		 * We check the LOADED_OK flag separately to protect us against buggy plugins
 		 * who ignore the result of geany_plugin_register() and register anyway */
-		p_geany_load_module(&plugin->public, module, GEANY_API_VERSION);
+		p_geany_load_module(&plugin->public);
 	}
 	else
 	{

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -262,7 +262,12 @@ static gint cmp_plugin_names(gconstpointer a, gconstpointer b)
 /** Register a plugin to Geany.
  *
  * The plugin will show up in the plugin manager. The user can interact with
- * it based on the callbacks it provides and installed GUI elements.
+ * it based on the functions it provides and installed GUI elements.
+ *
+ * You must initialize the info and funcs fields of @ref GeanyPlugin
+ * appropriately prior to calling this, otherwise registration will fail. For
+ * info at least a valid name must be set (possibly localized). For funcs,
+ * at least init() and cleanup() functions must be implemented and set.
  *
  * The return value must be checked. It may be FALSE if the plugin failed to register which can
  * mainly happen for two reasons (future Geany versions may add bad conditions):
@@ -273,7 +278,6 @@ static gint cmp_plugin_names(gconstpointer a, gconstpointer b)
  * @param api_version The API version the plugin is compiled against (pass GEANY_API_VERSION)
  * @param min_api_version The minimum API version required by the plugin
  * @param abi_version The exact ABI version the plugin is compiled against (pass GEANY_ABI_VERSION)
- * @param cbs A statically allocated @ref GeanyPluginFuncs structure filled with callbacks
  *
  * @return TRUE if the plugin was successfully registered. Otherwise FALSE.
  *
@@ -281,9 +285,10 @@ static gint cmp_plugin_names(gconstpointer a, gconstpointer b)
  **/
 GEANY_API_SYMBOL
 gboolean geany_plugin_register(GeanyPlugin *plugin, gint api_version, gint min_api_version,
-                               gint abi_version, GeanyPluginFuncs *cbs)
+                               gint abi_version)
 {
 	Plugin *p;
+	GeanyPluginFuncs *cbs = plugin->funcs;
 
 	g_return_val_if_fail(plugin != NULL, FALSE);
 
@@ -291,18 +296,12 @@ gboolean geany_plugin_register(GeanyPlugin *plugin, gint api_version, gint min_a
 	/* Prevent registering incompatible plugins. */
 	if (! plugin_check_version(p, PLUGIN_VERSION_CODE(api_version, abi_version)))
 		return FALSE;
-	/* If it ever becomes necessary we can save the api version in Plugin
-	 * and apply compat code on a per-plugin basis, because we learn about
-	 * the requested API version here. Also if we add to GeanyPluginFuncs then
-	 * we have to inspect the plugin's api so that we don't misinterpret
-	 * function pointers the plugin doesn't know anything about. */
-	p->cbs = *cbs;
 
 	/* Only init and cleanup callbacks are truly mandatory. */
 	if (! cbs->init || ! cbs->cleanup)
 	{
 		geany_debug("Plugin '%s' has no %s function - ignoring plugin!",
-				cbs->init ? "cleanup" : "init", g_module_name(p->module));
+				 g_module_name(p->module), cbs->init ? "cleanup" : "init");
 	}
 	else
 	{
@@ -311,6 +310,10 @@ gboolean geany_plugin_register(GeanyPlugin *plugin, gint api_version, gint min_a
 		if (! EMPTY(p->info.name))
 			p->flags = LOADED_OK;
 	}
+
+	/* If it ever becomes necessary we can save the api version in Plugin
+	 * and apply compat code on a per-plugin basis, because we learn about
+	 * the requested API version here. For now it's not necessary. */
 
 	return PLUGIN_LOADED_OK(p);
 }
@@ -535,8 +538,9 @@ plugin_new(const gchar *fname, gboolean load_plugin, gboolean add_to_list)
 	plugin->filename = g_strdup(fname);
 	plugin->public.geany_data = &geany_data;
 	plugin->public.priv = plugin;
-	/* Fields of plugin->info must to be initialized by the plugin */
+	/* Fields of plugin->info/funcs must to be initialized by the plugin */
 	plugin->public.info = &plugin->info;
+	plugin->public.funcs = &plugin->cbs;
 
 	g_module_symbol(module, "geany_load_module", (void *) &p_geany_load_module);
 	if (p_geany_load_module)

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -323,10 +323,11 @@ struct LegacyRealFuncs
 };
 
 /* Wrappers to support legacy plugins are below */
-static void legacy_init(GeanyPlugin *plugin, gpointer pdata)
+static gboolean legacy_init(GeanyPlugin *plugin, gpointer pdata)
 {
 	struct LegacyRealFuncs *h = pdata;
 	h->init(plugin->geany_data);
+	return TRUE;
 }
 
 static void legacy_cleanup(GeanyPlugin *plugin, gpointer pdata)
@@ -420,9 +421,10 @@ static void register_legacy_plugin(Plugin *plugin, GModule *module)
 }
 
 
-static void
+static gboolean
 plugin_load(Plugin *plugin)
 {
+	gboolean init_ok = TRUE;
 	/* Start the plugin. Legacy plugins require additional cruft. */
 	if (PLUGIN_IS_LEGACY(plugin))
 	{
@@ -442,6 +444,7 @@ plugin_load(Plugin *plugin)
 			*plugin_fields = &plugin->fields;
 		read_key_group(plugin);
 
+		/* Legacy plugin_init() cannot fail. */
 		plugin->cbs.init(&plugin->public, plugin->cb_data);
 
 		/* now read any plugin-owned data that might have been set in plugin_init() */
@@ -452,8 +455,11 @@ plugin_load(Plugin *plugin)
 	}
 	else
 	{
-		plugin->cbs.init(&plugin->public, plugin->cb_data);
+		init_ok = plugin->cbs.init(&plugin->public, plugin->cb_data);
 	}
+
+	if (! init_ok)
+		return FALSE;
 
 	/* new-style plugins set their callbacks in geany_load_module() */
 	if (plugin->cbs.callbacks)
@@ -465,6 +471,7 @@ plugin_load(Plugin *plugin)
 	active_plugin_list = g_list_insert_sorted(active_plugin_list, plugin, cmp_plugin_names);
 
 	geany_debug("Loaded:   %s (%s)", plugin->filename, plugin->info.name);
+	return TRUE;
 }
 
 
@@ -478,7 +485,7 @@ plugin_new(const gchar *fname, gboolean load_plugin, gboolean add_to_list)
 {
 	Plugin *plugin;
 	GModule *module;
-	gboolean (*p_geany_load_module)(GeanyPlugin *, GModule *, gint);
+	void (*p_geany_load_module)(GeanyPlugin *, GModule *, gint);
 
 	g_return_val_if_fail(fname, NULL);
 	g_return_val_if_fail(g_module_supported(), NULL);
@@ -559,8 +566,13 @@ plugin_new(const gchar *fname, gboolean load_plugin, gboolean add_to_list)
 		goto err;
 	}
 
-	if (load_plugin)
-		plugin_load(plugin);
+	if (load_plugin && !plugin_load(plugin))
+	{
+		/* Handle failing init same as failing to load for now. In future we
+		 * could present a informational UI or something */
+		geany_debug("Plugin failed to initialize \"%s\" - ignoring plugin!", fname);
+		goto err;
+	}
 
 	if (add_to_list)
 		plugin_list = g_list_prepend(plugin_list, plugin);

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -696,7 +696,11 @@ plugin_free(Plugin *plugin)
 	g_return_if_fail(plugin->module);
 
 	if (is_active_plugin(plugin))
+	{
 		plugin_cleanup(plugin);
+		if (plugin->cb_data_destroy)
+			plugin->cb_data_destroy(plugin->cb_data);
+	}
 
 	active_plugin_list = g_list_remove(active_plugin_list, plugin);
 
@@ -704,9 +708,6 @@ plugin_free(Plugin *plugin)
 		g_warning("%s: %s", plugin->filename, g_module_error());
 
 	plugin_list = g_list_remove(plugin_list, plugin);
-
-	if (plugin->cb_data_destroy)
-		plugin->cb_data_destroy(plugin->cb_data);
 	g_free(plugin->filename);
 	g_free(plugin);
 	plugin = NULL;

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -295,7 +295,7 @@ gboolean geany_plugin_register(GeanyPlugin *plugin, gint api_version, gint min_a
 	 * the requested API version here. Also if we add to GeanyPluginFuncs then
 	 * we have to inspect the plugin's api so that we don't misinterpret
 	 * function pointers the plugin doesn't know anything about. */
-	p->cbs.n = *cbs;
+	p->cbs = *cbs;
 
 	/* Only init and cleanup callbacks are truly mandatory. */
 	if (! cbs->init || ! cbs->cleanup)
@@ -314,6 +314,45 @@ gboolean geany_plugin_register(GeanyPlugin *plugin, gint api_version, gint min_a
 	return PLUGIN_LOADED_OK(p);
 }
 
+struct LegacyRealFuncs
+{
+	void       (*init) (GeanyData *data);
+	GtkWidget* (*configure) (GtkDialog *dialog);
+	void       (*help) (void);
+	void       (*cleanup) (void);
+};
+
+/* Wrappers to support legacy plugins are below */
+static void legacy_init(GeanyPlugin *plugin, gpointer pdata)
+{
+	struct LegacyRealFuncs *h = pdata;
+	h->init(plugin->geany_data);
+}
+
+static void legacy_cleanup(GeanyPlugin *plugin, gpointer pdata)
+{
+	struct LegacyRealFuncs *h = pdata;
+	/* Can be NULL because it's optional for legacy plugins */
+	if (h->cleanup)
+		h->cleanup();
+}
+
+static void legacy_help(GeanyPlugin *plugin, gpointer pdata)
+{
+	struct LegacyRealFuncs *h = pdata;
+	h->help();
+}
+
+static GtkWidget *legacy_configure(GeanyPlugin *plugin, GtkDialog *parent, gpointer pdata)
+{
+	struct LegacyRealFuncs *h = pdata;
+	return h->configure(parent);
+}
+
+static void free_legacy_cbs(gpointer data)
+{
+	g_slice_free(struct LegacyRealFuncs, data);
+}
 
 /* This function is the equivalent of geany_plugin_register() for legacy-style
  * plugins which we continue to load for the time being. */
@@ -321,24 +360,28 @@ static void register_legacy_plugin(Plugin *plugin, GModule *module)
 {
 	gint (*p_version_check) (gint abi_version);
 	void (*p_set_info) (PluginInfo *info);
+	void (*p_init) (GeanyData *geany_data);
 	GeanyData **p_geany_data;
+	struct LegacyRealFuncs *h;
 
-#define CHECK_FUNC(__x, p)                                                                \
-	if (! g_module_symbol(module, "plugin_" #__x, (void *) (p)))                          \
+#define CHECK_FUNC(__x)                                                                   \
+	if (! g_module_symbol(module, "plugin_" #__x, (void *) (&p_##__x)))                   \
 	{                                                                                     \
 		geany_debug("Plugin \"%s\" has no plugin_" #__x "() function - ignoring plugin!", \
 				g_module_name(plugin->module));                                           \
 		return;                                                                           \
 	}
-	CHECK_FUNC(version_check, &p_version_check);
-	CHECK_FUNC(set_info, &p_set_info);
-	CHECK_FUNC(init, &plugin->cbs.l.init);
+	CHECK_FUNC(version_check);
+	CHECK_FUNC(set_info);
+	CHECK_FUNC(init);
 #undef CHECK_FUNC
 
 	/* We must verify the version first. If the plugin has become incompatible any
 	 * further actions should be considered invalid and therefore skipped. */
 	if (! plugin_check_version(plugin, p_version_check(GEANY_ABI_VERSION)))
 		return;
+
+	h = g_slice_new(struct LegacyRealFuncs);
 
 	/* Since the version check passed we can proceed with setting basic fields and
 	 * calling its set_info() (which might want to call Geany functions already). */
@@ -349,31 +392,38 @@ static void register_legacy_plugin(Plugin *plugin, GModule *module)
 	p_set_info(&plugin->info);
 
 	/* If all went well we can set the remaining callbacks and let it go for good. */
-	g_module_symbol(module, "plugin_configure", (void *) &plugin->cbs.l.configure);
-	g_module_symbol(module, "plugin_configure_single", (void *) &plugin->cbs.l.configure_single);
-	g_module_symbol(module, "plugin_help", (void *) &plugin->cbs.l.help);
-	g_module_symbol(module, "plugin_cleanup", (void *) &plugin->cbs.l.cleanup);
-
+	h->init = p_init;
+	g_module_symbol(module, "plugin_configure", (void *) &h->configure);
+	g_module_symbol(module, "plugin_configure_single", (void *) &plugin->configure_single);
+	g_module_symbol(module, "plugin_help", (void *) &h->help);
+	g_module_symbol(module, "plugin_cleanup", (void *) &h->cleanup);
+	/* pointer to callbacks struct can be stored directly, no wrapper necessary */
+	g_module_symbol(module, "plugin_callbacks", (void *) &plugin->cbs.callbacks);
 	if (app->debug_mode)
 	{
-		if (plugin->cbs.l.configure && plugin->cbs.l.configure_single)
+		if (h->configure && plugin->configure_single)
 			g_warning("Plugin '%s' implements plugin_configure_single() unnecessarily - "
 				"only plugin_configure() will be used!",
 				plugin->info.name);
-		if (plugin->cbs.l.cleanup == NULL)
+		if (h->cleanup == NULL)
 			g_warning("Plugin '%s' has no plugin_cleanup() function - there may be memory leaks!",
 				plugin->info.name);
 	}
 
+	plugin->cbs.init = legacy_init;
+	plugin->cbs.cleanup = legacy_cleanup;
+	plugin->cbs.configure = h->configure ? legacy_configure : NULL;
+	plugin->cbs.help = h->help ? legacy_help : NULL;
+
 	plugin->flags = LOADED_OK | IS_LEGACY;
+	geany_plugin_set_data(&plugin->public, h, free_legacy_cbs);
 }
 
 
 static void
 plugin_load(Plugin *plugin)
 {
-	PluginCallback *callbacks;
-
+	/* Start the plugin. Legacy plugins require additional cruft. */
 	if (PLUGIN_IS_LEGACY(plugin))
 	{
 		GeanyPlugin **p_geany_plugin;
@@ -392,26 +442,22 @@ plugin_load(Plugin *plugin)
 			*plugin_fields = &plugin->fields;
 		read_key_group(plugin);
 
-		/* start the plugin */
-		plugin->cbs.l.init(&geany_data);
+		plugin->cbs.init(&plugin->public, plugin->cb_data);
 
 		/* now read any plugin-owned data that might have been set in plugin_init() */
 		if (plugin->fields.flags & PLUGIN_IS_DOCUMENT_SENSITIVE)
 		{
 			ui_add_document_sensitive(plugin->fields.menu_item);
 		}
-
-		g_module_symbol(plugin->module, "plugin_callbacks", (void *) &callbacks);
 	}
 	else
 	{
-		plugin->cbs.n.init(&plugin->public, plugin->cb_data);
-		callbacks = plugin->cbs.n.callbacks;
+		plugin->cbs.init(&plugin->public, plugin->cb_data);
 	}
 
 	/* new-style plugins set their callbacks in geany_load_module() */
-	if (callbacks)
-		add_callbacks(plugin, callbacks);
+	if (plugin->cbs.callbacks)
+		add_callbacks(plugin, plugin->cbs.callbacks);
 
 	/* remember which plugins are active.
 	 * keep list sorted so tools menu items and plugin preference tabs are
@@ -609,11 +655,8 @@ plugin_cleanup(Plugin *plugin)
 {
 	GtkWidget *widget;
 
-	/* With geany_plugin_register() cleanup is mandatory */
-	if (! PLUGIN_IS_LEGACY(plugin))
-		plugin->cbs.n.cleanup(&plugin->public, plugin->cb_data);
-	else if (plugin->cbs.l.cleanup)
-		plugin->cbs.l.cleanup();
+	/* With geany_register_plugin cleanup is mandatory */
+	plugin->cbs.cleanup(&plugin->public, plugin->cb_data);
 
 	remove_callbacks(plugin);
 	remove_sources(plugin);
@@ -936,12 +979,7 @@ gboolean plugins_have_preferences(void)
 	foreach_list(item, active_plugin_list)
 	{
 		Plugin *plugin = item->data;
-		gboolean result;
-		if (! PLUGIN_IS_LEGACY(plugin))
-			result = plugin->cbs.n.configure != NULL;
-		else
-			result = plugin->cbs.l.configure != NULL || plugin->cbs.l.configure_single != NULL;
-		if (result)
+		if (plugin->configure_single != NULL || plugin->cbs.configure != NULL)
 			return TRUE;
 	}
 
@@ -988,16 +1026,8 @@ static void pm_update_buttons(Plugin *p)
 
 	if (p != NULL && is_active_plugin(p))
 	{
-		if (PLUGIN_IS_LEGACY(p))
-		{
-			has_configure = p->cbs.l.configure || p->cbs.l.configure_single;
-			has_help = p->cbs.l.help != NULL;
-		}
-		else
-		{
-			has_configure = p->cbs.n.configure != NULL;
-			has_help = p->cbs.n.help != NULL;
-		}
+		has_configure = p->cbs.configure || p->configure_single;
+		has_help = p->cbs.help != NULL;
 		has_keybindings = p->key_group && p->key_group->plugin_key_count;
 	}
 
@@ -1336,12 +1366,7 @@ static void pm_on_plugin_button_clicked(G_GNUC_UNUSED GtkButton *button, gpointe
 			if (GPOINTER_TO_INT(user_data) == PM_BUTTON_CONFIGURE)
 				plugin_show_configure(&p->public);
 			else if (GPOINTER_TO_INT(user_data) == PM_BUTTON_HELP)
-			{
-				if (PLUGIN_IS_LEGACY(p))
-					p->cbs.l.help();
-				else
-					p->cbs.n.help(&p->public, p->cb_data);
-			}
+				p->cbs.help(&p->public, p->cb_data);
 			else if (GPOINTER_TO_INT(user_data) == PM_BUTTON_KEYBINDINGS && p->key_group && p->key_group->plugin_key_count > 0)
 				keybindings_dialog_show_prefs_scroll(p->info.name);
 		}

--- a/src/pluginutils.c
+++ b/src/pluginutils.c
@@ -310,7 +310,7 @@ GeanyKeyGroup *plugin_set_key_group(GeanyPlugin *plugin,
 
 static void on_pref_btn_clicked(gpointer btn, Plugin *p)
 {
-	p->configure_single(main_widgets.window);
+	p->cbs.l.configure_single(main_widgets.window);
 }
 
 
@@ -318,10 +318,16 @@ static GtkWidget *create_pref_page(Plugin *p, GtkWidget *dialog)
 {
 	GtkWidget *page = NULL;	/* some plugins don't have prefs */
 
-	if (p->configure)
+	if (!PLUGIN_IS_LEGACY(p))
 	{
-		page = p->configure(GTK_DIALOG(dialog));
+		if (p->cbs.n.configure)
+			page = p->cbs.n.configure(&p->public, GTK_DIALOG(dialog), p->cb_data);
+	}
+	else if (p->cbs.l.configure)
+		page = p->cbs.l.configure(GTK_DIALOG(dialog));
 
+	if (page)
+	{
 		if (! GTK_IS_WIDGET(page))
 		{
 			geany_debug("Invalid widget returned from plugin_configure() in plugin \"%s\"!",
@@ -338,7 +344,7 @@ static GtkWidget *create_pref_page(Plugin *p, GtkWidget *dialog)
 			gtk_box_pack_start(GTK_BOX(page), align, TRUE, TRUE, 0);
 		}
 	}
-	else if (p->configure_single)
+	else if (PLUGIN_IS_LEGACY(p) && p->cbs.l.configure_single)
 	{
 		GtkWidget *align = gtk_alignment_new(0.5, 0.5, 0, 0);
 		GtkWidget *btn;
@@ -421,12 +427,12 @@ void plugin_show_configure(GeanyPlugin *plugin)
 	}
 	p = plugin->priv;
 
-	if (p->configure)
+	if (!PLUGIN_IS_LEGACY(p) || p->cbs.l.configure)
 		configure_plugins(p);
 	else
 	{
-		g_return_if_fail(p->configure_single);
-		p->configure_single(main_widgets.window);
+		g_return_if_fail(p->cbs.l.configure_single);
+		p->cbs.l.configure_single(main_widgets.window);
 	}
 }
 

--- a/src/pluginutils.c
+++ b/src/pluginutils.c
@@ -528,10 +528,10 @@ void plugin_builder_connect_signals(GeanyPlugin *plugin,
  * @ref geany_plugin_register(). So-called legacy plugins cannot not use this function.
  *
  * @param plugin The plugin provided by Geany
- * @param pdata pdata The plugin's data to associate, must not be @c NULL
+ * @param pdata The plugin's data to associate, must not be @c NULL
  * @param free_func The destroy notify
  *
- * @since 1.26
+ * @since 1.26 (API 225)
  */
 GEANY_API_SYMBOL
 void geany_plugin_set_data(GeanyPlugin *plugin, gpointer pdata, GDestroyNotify free_func)

--- a/src/pluginutils.c
+++ b/src/pluginutils.c
@@ -310,7 +310,7 @@ GeanyKeyGroup *plugin_set_key_group(GeanyPlugin *plugin,
 
 static void on_pref_btn_clicked(gpointer btn, Plugin *p)
 {
-	p->cbs.l.configure_single(main_widgets.window);
+	p->configure_single(main_widgets.window);
 }
 
 
@@ -318,16 +318,9 @@ static GtkWidget *create_pref_page(Plugin *p, GtkWidget *dialog)
 {
 	GtkWidget *page = NULL;	/* some plugins don't have prefs */
 
-	if (!PLUGIN_IS_LEGACY(p))
+	if (p->cbs.configure)
 	{
-		if (p->cbs.n.configure)
-			page = p->cbs.n.configure(&p->public, GTK_DIALOG(dialog), p->cb_data);
-	}
-	else if (p->cbs.l.configure)
-		page = p->cbs.l.configure(GTK_DIALOG(dialog));
-
-	if (page)
-	{
+		page = p->cbs.configure(&p->public, GTK_DIALOG(dialog), p->cb_data);
 		if (! GTK_IS_WIDGET(page))
 		{
 			geany_debug("Invalid widget returned from plugin_configure() in plugin \"%s\"!",
@@ -344,7 +337,7 @@ static GtkWidget *create_pref_page(Plugin *p, GtkWidget *dialog)
 			gtk_box_pack_start(GTK_BOX(page), align, TRUE, TRUE, 0);
 		}
 	}
-	else if (PLUGIN_IS_LEGACY(p) && p->cbs.l.configure_single)
+	else if (p->configure_single)
 	{
 		GtkWidget *align = gtk_alignment_new(0.5, 0.5, 0, 0);
 		GtkWidget *btn;
@@ -427,12 +420,12 @@ void plugin_show_configure(GeanyPlugin *plugin)
 	}
 	p = plugin->priv;
 
-	if (!PLUGIN_IS_LEGACY(p) || p->cbs.l.configure)
+	if (p->cbs.configure)
 		configure_plugins(p);
 	else
 	{
-		g_return_if_fail(p->cbs.l.configure_single);
-		p->cbs.l.configure_single(main_widgets.window);
+		g_return_if_fail(p->configure_single);
+		p->configure_single(main_widgets.window);
 	}
 }
 
@@ -531,7 +524,8 @@ void plugin_builder_connect_signals(GeanyPlugin *plugin,
  * by passing g_object_unref() as @a free_func, so that member functions can be used
  * for the @ref GeanyPluginFuncs (via wrappers) but you can set completely custom data.
  *
- * Be aware that this can only be called once.
+ * Be aware that this can only be called once and only by plugins registered via
+ * @ref geany_plugin_register(). So-called legacy plugins cannot not use this function.
  *
  * @param plugin The plugin provided by Geany
  * @param pdata pdata The plugin's data to associate, must not be @c NULL

--- a/src/pluginutils.c
+++ b/src/pluginutils.c
@@ -561,4 +561,12 @@ void geany_plugin_set_data(GeanyPlugin *plugin, gpointer pdata, GDestroyNotify f
 }
 
 
+/* Get the API version at the time when Geany was compiled */
+GEANY_API_SYMBOL
+gint geany_api_version(void)
+{
+	return GEANY_API_VERSION;
+}
+
+
 #endif

--- a/src/pluginutils.c
+++ b/src/pluginutils.c
@@ -520,4 +520,51 @@ void plugin_builder_connect_signals(GeanyPlugin *plugin,
 }
 
 
+/** Add additional data that corresponds to the plugin.
+ *
+ * This is the data pointer passed to the individual plugin callbacks. It may be
+ * called as soon as geany_plugin_register() was called with success. When the
+ * plugin is unloaded, @a free_func is invoked for the data, which connects the
+ * data to the plugin's own life time.
+ *
+ * One intended use case is to set GObjects as data and have them destroyed automatically
+ * by passing g_object_unref() as @a free_func, so that member functions can be used
+ * for the @ref GeanyPluginFuncs (via wrappers) but you can set completely custom data.
+ *
+ * Be aware that this can only be called once.
+ *
+ * @param plugin The plugin provided by Geany
+ * @param pdata pdata The plugin's data to associate, must not be @c NULL
+ * @param free_func The destroy notify
+ *
+ * @since 1.26
+ */
+GEANY_API_SYMBOL
+void geany_plugin_set_data(GeanyPlugin *plugin, gpointer pdata, GDestroyNotify free_func)
+{
+	Plugin *p = plugin->priv;
+
+	g_return_if_fail(PLUGIN_LOADED_OK(p));
+	/* Do not allow calling this only to set a notify. */
+	g_return_if_fail(pdata != NULL);
+	/* The rationale to allow only setting the data once is the following:
+	 * In the future we want to support proxy plugins (which bind non-C plugins to
+	 * Geany's plugin api). These proxy plugins might need to own the data pointer
+	 * on behalf of the proxied plugin. However, if not, then the plugin should be
+	 * free to use it. This way we can make sure the plugin doesn't accidently trash
+	 * its proxy.
+	 *
+	 * Better a more limited API now that can be opened up later than a potentially
+	 * wrong one that can only be replaced by another one. */
+	if (p->cb_data != NULL || p->cb_data_destroy != NULL)
+	{
+		g_warning("Double call to %s(), ignored!", G_STRFUNC);
+		return;
+	}
+
+	p->cb_data = pdata;
+	p->cb_data_destroy = free_func;
+}
+
+
 #endif


### PR DESCRIPTION
Since the parameters are unlikely to be used much, remove them and still provide a way to check Geany's API version at run-time. Ignore it if these arguments are likely to be widely used, I can't think of too much use that the changes here don't support.
